### PR TITLE
bug from issue 347

### DIFF
--- a/common/util/src/error.rs
+++ b/common/util/src/error.rs
@@ -103,7 +103,7 @@ pub enum Error {
     MetadataProposeCountVerifyFail,
 
     // withdraw
-    WrongOutWithdrawArraySize = 110,
+    WithdrawWrongRecordSize = 110,
     WrongLockEpoch,
     WrongOutWithdrawEpoch,
     WrongOutWithdraw,
@@ -114,9 +114,10 @@ pub enum Error {
     BadUnstake,
     WithdrawDataEmpty,
     WithdrawBadSudtDataFormat,
+    WithdrawZeroAmount,
 
     // reward
-    RewardWrongAmount,
+    RewardWrongAmount = -10,
     RewardProposeCountBottomFail,
     RewardProposeCountTopFail,
     RewardStakeAmountBottomFail,
@@ -125,10 +126,10 @@ pub enum Error {
     RewardOldNewMismatch,
 
     // requirement
-    CommissionRateTooLarge = -10,
+    CommissionRateTooLarge = -20,
 
     // molecule::error::VerificationError
-    TotalSizeNotMatch = -20,
+    TotalSizeNotMatch = -30,
     HeaderIsBroken,
     UnknownItem,
     OffsetsNotMatch,

--- a/common/util/src/error.rs
+++ b/common/util/src/error.rs
@@ -122,12 +122,13 @@ pub enum Error {
     RewardStakeAmountBottomFail,
     RewardStakeAmountTopFail,
     RewardWrongDelegateAmount,
+    RewardOldNewMismatch,
 
     // requirement
-    CommissionRateTooLarge,
+    CommissionRateTooLarge = -10,
 
     // molecule::error::VerificationError
-    TotalSizeNotMatch = -10,
+    TotalSizeNotMatch = -20,
     HeaderIsBroken,
     UnknownItem,
     OffsetsNotMatch,

--- a/common/util/src/smt.rs
+++ b/common/util/src/smt.rs
@@ -91,33 +91,21 @@ pub fn u64_to_byte32(epoch: &u64) -> [u8; 32] {
     buf
 }
 
-#[derive(Clone, Copy, Default, Eq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug)]
 pub struct LockInfo {
     pub addr: [u8; 20], // address of locker(staker or delegator), smt key
     pub amount: u128,   // amount locked, smt value
 }
 
-// impl LockInfo {
-//     pub fn new(stake_info: &stake_reader::StakeInfo) -> Self {
-//         let mut identity = [0u8; 20];
-//         identity.copy_from_slice(&stake_info.addr());
-//         Self {
-//             addr: identity,
-//             amount: bytes_to_u128(&stake_info.amount()),
-//         }
-//     }
-// }
-
-impl Ord for LockInfo {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let order = other.addr.cmp(&self.addr);
-        order
+impl PartialOrd for LockInfo {
+    fn partial_cmp(&self, other: &LockInfo) -> Option<Ordering> {
+        self.amount.partial_cmp(&other.amount)
     }
 }
 
-impl PartialEq for LockInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.addr == other.addr
+impl Ord for LockInfo {
+    fn cmp(&self, other: &LockInfo) -> Ordering {
+        other.partial_cmp(self).unwrap()
     }
 }
 

--- a/contracts/metadata/src/entry.rs
+++ b/contracts/metadata/src/entry.rs
@@ -101,6 +101,30 @@ pub fn main() -> Result<(), Error> {
     Ok(())
 }
 
+fn is_type_ids_equal(ids1: &TypeIds, ids2: &TypeIds) -> bool {
+    if ids1.issue_type_id() != ids2.issue_type_id()
+        || ids1.selection_type_id() != ids2.selection_type_id()
+        || ids1.xudt_owner_lock_hash() != ids2.xudt_owner_lock_hash()
+        || ids1.metadata_code_hash() != ids2.metadata_code_hash()
+        || ids1.metadata_type_id() != ids2.metadata_type_id()
+        || ids1.checkpoint_code_hash() != ids2.checkpoint_code_hash()
+        || ids1.checkpoint_type_id() != ids2.checkpoint_type_id()
+        || ids1.stake_smt_code_hash() != ids2.stake_smt_code_hash()
+        || ids1.stake_smt_type_id() != ids2.stake_smt_type_id()
+        || ids1.delegate_smt_code_hash() != ids2.delegate_smt_code_hash()
+        || ids1.delegate_smt_type_id() != ids2.delegate_smt_type_id()
+        || ids1.reward_code_hash() != ids2.reward_code_hash()
+        || ids1.reward_type_id() != ids2.reward_type_id()
+        || ids1.xudt_type_hash() != ids2.xudt_type_hash()
+        || ids1.stake_at_code_hash() != ids2.stake_at_code_hash()
+        || ids1.delegate_at_code_hash() != ids2.delegate_at_code_hash()
+        || ids1.withdraw_code_hash() != ids2.withdraw_code_hash()
+    {
+        return false;
+    }
+    true
+}
+
 // verify data correctness exclude propose count and election
 fn verify_chain_config(
     input_metadata: &MetadataCellData,
@@ -116,6 +140,16 @@ fn verify_chain_config(
     let metadata_list_size = 2;
     if input_metadatas.len() != metadata_list_size || output_metadatas.len() != metadata_list_size {
         return Err(Error::MetadataSizeWrong);
+    }
+
+    if input_metadata.version() != output_metadata.version()
+        || input_metadata.base_reward() != output_metadata.base_reward()
+        || input_metadata.half_epoch() != output_metadata.half_epoch()
+        || input_metadata.propose_minimum_rate() != output_metadata.propose_minimum_rate()
+        || input_metadata.propose_discount_rate() != output_metadata.propose_discount_rate()
+        || !is_type_ids_equal(&input_metadata.type_ids(), &output_metadata.type_ids())
+    {
+        return Err(Error::MetadataInputOutputMismatch);
     }
 
     let input_metadata1 = input_metadatas.get(1);

--- a/contracts/reward/src/entry.rs
+++ b/contracts/reward/src/entry.rs
@@ -116,8 +116,10 @@ fn verify_old_new_claim_smt(
         &new_reward_smt_data,
     )?;
 
-    if old_reward_smt_data.metadata_type_id() != new_reward_smt_data.metadata_type_id() {
-        return Err(Error::MisMatchMetadataTypeId);
+    if old_reward_smt_data.version() != new_reward_smt_data.version()
+        || old_reward_smt_data.metadata_type_id() != new_reward_smt_data.metadata_type_id()
+    {
+        return Err(Error::RewardOldNewMismatch);
     }
 
     Ok((

--- a/contracts/reward/src/entry.rs
+++ b/contracts/reward/src/entry.rs
@@ -366,16 +366,16 @@ fn calculate_reward(
             let commission_fee = delegate_reward * obj.commission_rate as u128 / 100;
             epoch_reward += commission_fee;
         } else {
-            // delegator reward, miner can only be staker or delegator
-            let delegate_amount = {
-                match obj.delegate_amount {
-                    Some(amount) => amount,
-                    None => return Err(Error::RewardWrongDelegateAmount),
+            match obj.delegate_amount {
+                // delegator reward, miner can only be staker or delegator
+                Some(amount) => {
+                    epoch_reward = amount * delegate_reward * (100 - obj.commission_rate as u128)
+                        / 100
+                        / obj.total_delegate_amount
                 }
-            };
-            epoch_reward = delegate_amount * delegate_reward * (100 - obj.commission_rate as u128)
-                / 100
-                / obj.total_delegate_amount;
+                // miner not staker or delegator
+                None => epoch_reward = 0,
+            }
         }
     }
     Ok(epoch_reward)

--- a/contracts/stake-smt/src/entry.rs
+++ b/contracts/stake-smt/src/entry.rs
@@ -212,7 +212,7 @@ fn verify_old_stake_infos(
     Ok(())
 }
 
-fn verify_staker_seletion(
+fn verify_staker_selection(
     stake_infos_set: &BTreeSet<LockInfo>,
     new_stake_smt_data: &StakeSmtCellData,
     stake_smt_update_infos: &StakeSmtUpdateInfo,
@@ -248,7 +248,10 @@ fn verify_staker_seletion(
         new_epoch_root,
         new_epoch_proof,
     )?;
-    debug!("verify_staker_seletion verify_2layer_smt result:{}", result);
+    debug!(
+        "verify_staker_selection verify_2layer_smt result:{}",
+        result
+    );
     if !result {
         return Err(Error::StakeSmtVerifySelectionError);
     }
@@ -362,8 +365,8 @@ fn update_stake_smt(
         )?;
     }
 
-    debug!("verify_staker_seletion");
-    verify_staker_seletion(
+    debug!("verify_staker_selection");
+    verify_staker_selection(
         &stake_infos_set,
         &new_stake_smt_data,
         &stake_smt_update_infos,

--- a/tests/src/delegate.rs
+++ b/tests/src/delegate.rs
@@ -275,6 +275,7 @@ fn test_delegate_smt_redeem_success() {
 
     let delegator_keypair = Generator::random_keypair();
     let staker_keypair = Generator::random_keypair();
+    let staker_addr = pubkey_to_addr(&staker_keypair.1.serialize());
     println!(
         "staker pubkey: {:?}",
         blake160(&staker_keypair.1.serialize())
@@ -366,6 +367,16 @@ fn test_delegate_smt_redeem_success() {
             .build(),
         Bytes::from(axon_withdraw_at_cell_data(0, input_withdraw_data)), // delegate at cell
     );
+
+    let (delegate_requirement_script_dep, stake_at_script_dep, stake_at_lock_script) =
+        axon_delegate_requirement_and_stake_at_cell(
+            &metadata_type_script,
+            &always_success_out_point,
+            &always_success_lock_script,
+            &mut context,
+            &staker_keypair,
+            &staker_addr,
+        );
 
     // prepare tx inputs and outputs
     let inputs = vec![
@@ -489,7 +500,7 @@ fn test_delegate_smt_redeem_success() {
         100,
         100,
         propose_count_smt_root,
-        &metadata_type_script.code_hash(),
+        &stake_at_lock_script.code_hash(),
         &delegate_at_lock_script.code_hash(),
         &withdraw_lock_script.code_hash(),
     );
@@ -571,6 +582,8 @@ fn test_delegate_smt_redeem_success() {
         .cell_dep(always_success_script_dep)
         .cell_dep(checkpoint_script_dep)
         .cell_dep(metadata_script_dep)
+        .cell_dep(delegate_requirement_script_dep)
+        .cell_dep(stake_at_script_dep)
         .build();
     let tx = context.complete_tx(tx);
 
@@ -639,6 +652,7 @@ fn test_delegate_smt_increase_success() {
 
     let delegator_keypair = Generator::random_keypair();
     let staker_keypair = Generator::random_keypair();
+    let staker_addr = pubkey_to_addr(&staker_keypair.1.serialize());
     println!(
         "staker pubkey: {:?}",
         blake160(&staker_keypair.1.serialize())
@@ -689,6 +703,16 @@ fn test_delegate_smt_increase_success() {
         &staker_keypair.1,
         3,
     );
+
+    let (delegate_requirement_script_dep, stake_at_script_dep, stake_at_lock_script) =
+        axon_delegate_requirement_and_stake_at_cell(
+            &metadata_type_script,
+            &always_success_out_point,
+            &always_success_lock_script,
+            &mut context,
+            &staker_keypair,
+            &staker_addr,
+        );
 
     // prepare tx inputs and outputs
     let inputs = vec![
@@ -789,7 +813,7 @@ fn test_delegate_smt_increase_success() {
         100,
         100,
         propose_count_smt_root,
-        &metadata_type_script.code_hash(),
+        &stake_at_lock_script.code_hash(),
         &delegate_at_lock_script.code_hash(),
         &metadata_type_script.code_hash(),
     );
@@ -872,6 +896,8 @@ fn test_delegate_smt_increase_success() {
         .cell_dep(always_success_script_dep)
         .cell_dep(checkpoint_script_dep)
         .cell_dep(metadata_script_dep)
+        .cell_dep(delegate_requirement_script_dep)
+        .cell_dep(stake_at_script_dep)
         .build();
     let tx = context.complete_tx(tx);
 

--- a/tests/src/reward.rs
+++ b/tests/src/reward.rs
@@ -10,7 +10,6 @@ use axon_types::reward::{
     EpochRewardStakeInfo, EpochRewardStakeInfos, NotClaimInfo, RewardDelegateInfos,
     RewardSmtCellData, RewardStakeInfo, RewardStakeInfos, RewardWitness,
 };
-use axon_types::stake::{DelegateRequirementArgs, DelegateRequirementInfo, StakeArgs};
 use ckb_testtool::ckb_crypto::secp::Generator;
 use ckb_testtool::ckb_types::core::ScriptHashType;
 use ckb_testtool::ckb_types::{bytes::Bytes, core::TransactionBuilder, packed::*, prelude::*};
@@ -166,74 +165,15 @@ fn test_reward_success() {
         )
         .build();
 
-    let requirement_type_id = [1u8; 32];
-    let delegate_requirement_args = DelegateRequirementArgs::new_builder()
-        .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
-        .requirement_type_id(axon_array32_byte32(requirement_type_id))
-        .build();
-    let delegate_requirement_type_script = context
-        .build_script_with_hash_type(
+    let (delegate_requirement_script_dep, stake_at_script_dep, stake_at_lock_script) =
+        axon_delegate_requirement_and_stake_at_cell(
+            &metadata_type_script,
             &always_success_out_point,
-            ScriptHashType::Type,
-            delegate_requirement_args.as_bytes(),
-        )
-        .expect("delegate requirement type script");
-    let delegate_requirement_cell_data = axon_delegate_requirement_cell_data(10);
-    let delegate_requirement_script_dep = CellDep::new_builder()
-        .out_point(
-            context.create_cell(
-                CellOutput::new_builder()
-                    .capacity(1000.pack())
-                    .lock(always_success_lock_script.clone())
-                    .type_(Some(delegate_requirement_type_script.clone()).pack())
-                    .build(),
-                delegate_requirement_cell_data.as_bytes(),
-            ),
-        )
-        .build();
-
-    let delegate_requirement_info = DelegateRequirementInfo::new_builder()
-        .code_hash(axon_byte32(&delegate_requirement_type_script.code_hash()))
-        .requirement(delegate_requirement_args)
-        .build();
-    let stake_args = StakeArgs::new_builder()
-        .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
-        .stake_addr(axon_byte20_identity(&staker_addr))
-        .build();
-    // prepare stake lock_script
-    let stake_at_lock_script = context
-        .build_script_with_hash_type(
-            &always_success_out_point,
-            ScriptHashType::Type,
-            stake_args.as_bytes(),
-        )
-        .expect("stake script");
-    // println!(
-    //     "stake_at_code_hash: {:?}, staker:{:?}, stake_args: {:?}",
-    //     stake_at_lock_script.code_hash().as_slice(),
-    //     staker_addr,
-    //     stake_args.as_slice()
-    // );
-    let input_stake_info_delta = axon_types::stake::StakeInfoDelta::new_builder().build();
-    let input_stake_at_data = axon_stake_at_cell_data_without_amount(
-        0,
-        &keypair.1.serialize(),
-        axon_byte20_identity(&staker_addr),
-        &metadata_type_script.calc_script_hash(),
-        input_stake_info_delta,
-        delegate_requirement_info,
-    );
-    let stake_at_script_dep = CellDep::new_builder()
-        .out_point(
-            context.create_cell(
-                CellOutput::new_builder()
-                    .capacity(1000.pack())
-                    .lock(stake_at_lock_script.clone())
-                    .build(),
-                Bytes::from(axon_stake_at_cell_data(100, input_stake_at_data)),
-            ),
-        )
-        .build();
+            &always_success_lock_script,
+            &mut context,
+            &keypair,
+            &staker_addr,
+        );
 
     // prepare tx inputs and outputs
     let stake_amount = 1000;

--- a/tests/src/stake.rs
+++ b/tests/src/stake.rs
@@ -1215,3 +1215,35 @@ fn test_stake_election_success() {
         .expect("pass verification");
     println!("consume cycles: {}", cycles);
 }
+
+#[test]
+fn test_lock_info_sort_success() {
+    let lock_info0 = LockInfo {
+        addr: [0u8; 20],
+        amount: 200,
+    };
+    let lock_info1 = LockInfo {
+        addr: [1u8; 20],
+        amount: 100,
+    };
+    let lock_info2 = LockInfo {
+        addr: [2u8; 20],
+        amount: 300,
+    };
+
+    let mut lock_infos = BTreeSet::new();
+    lock_infos.insert(lock_info0);
+    lock_infos.insert(lock_info1);
+    lock_infos.insert(lock_info2);
+
+    let iter = lock_infos.iter();
+    let mut top_3quorum = iter.take(2);
+    let mut new_stake_infos_set = BTreeSet::new();
+    while let Some(elem) = top_3quorum.next() {
+        new_stake_infos_set.insert((*elem).clone());
+    }
+
+    for lock_info in &new_stake_infos_set {
+        println!("LockInfo: {:?}", lock_info);
+    }
+}


### PR DESCRIPTION
- [x] When staking/delegating for the first time, the withdraw AT cell's info should be validated to be empty, otherwise users could get AT out of air.
- [x] In stake SMT, delegate SMT, and metadata, when pruning/electing the smallest top N amount should be kept instead of the largest top N.
- [ ] In delegate SMT, if a DelegateInfoDelta's total amount becomes 0, should it still be kept? Keeping it will make the DelegateInfoDeltas array grow indefinitely. Not keeping it may cause output validation failures, since the corresponding delta no longer exists.
- [x] In delegate SMT, the maximum number of delegators should be retrieved from the requirement cell.
- [x] In reward, need to consider the case where a user was neither a validator nor delegator in an epoch, in which case there is no reward.
- [x] Metadata cell fields related to reward like base_reward can be arbitrarily modified, allowing stakers to get unlimited rewards.
- [ ] The total_amount of the DelegateInfoDelta in the delegate AT cell is not validated. Should validation be added?