### PR TITLE
test cased for delegate & stake

### DIFF
--- a/common/util/src/error.rs
+++ b/common/util/src/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     BadSudtDataFormat,
     BadInaugurationEpoch,
     BadStakeChange,
-    RedeemExceedLimit,
+    UnstakeTooMuch,
     BadStakeStakeChange,
     BadStakeRedeemChange,
     IllegalDefaultStakeInfo,

--- a/common/util/src/error.rs
+++ b/common/util/src/error.rs
@@ -72,7 +72,7 @@ pub enum Error {
     MismatchXudtTypeId,
 
     // delegate
-    FirstRedeemError = 80,
+    UnDelegateTooMuch = 80,
     BadDelegateChange,
     StaleDelegateInfo,
     IllegalDefaultDelegateInfo,

--- a/common/util/src/smt.rs
+++ b/common/util/src/smt.rs
@@ -103,16 +103,6 @@ impl PartialOrd for LockInfo {
             Some(Ordering::Equal) => self.addr.partial_cmp(&other.addr),
             ordering => ordering,
         }
-        // let order = self.amount.partial_cmp(&other.amount);
-        // if let Some(order) = order {
-        //     if order == Ordering::Equal {
-        //         self.addr.partial_cmp(&other.addr)
-        //     } else {
-        //         Some(order)
-        //     }
-        // } else {
-        //     order
-        // }
     }
 }
 

--- a/common/util/src/smt.rs
+++ b/common/util/src/smt.rs
@@ -99,7 +99,20 @@ pub struct LockInfo {
 
 impl PartialOrd for LockInfo {
     fn partial_cmp(&self, other: &LockInfo) -> Option<Ordering> {
-        self.amount.partial_cmp(&other.amount)
+        match self.amount.partial_cmp(&other.amount) {
+            Some(Ordering::Equal) => self.addr.partial_cmp(&other.addr),
+            ordering => ordering,
+        }
+        // let order = self.amount.partial_cmp(&other.amount);
+        // if let Some(order) = order {
+        //     if order == Ordering::Equal {
+        //         self.addr.partial_cmp(&other.addr)
+        //     } else {
+        //         Some(order)
+        //     }
+        // } else {
+        //     order
+        // }
     }
 }
 

--- a/contracts/delegate-smt/src/types.rs
+++ b/contracts/delegate-smt/src/types.rs
@@ -11,6 +11,7 @@ impl WithdrawAmountMap {
         }
     }
 
+    // if exist, it will accumulate
     pub fn insert(&mut self, addr: [u8; 20], amount: u128) {
         let entry = self.map.entry(addr).or_insert(0);
         *entry += amount;

--- a/contracts/delegate/src/entry.rs
+++ b/contracts/delegate/src/entry.rs
@@ -67,7 +67,7 @@ pub fn main() -> Result<(), Error> {
                         &type_ids.checkpoint_code_hash(),
                         &type_ids.checkpoint_type_id(),
                     );
-                    debug!("checkpoint_script_hash: {:?}", checkpoint_script_hash);
+                    // debug!("checkpoint_script_hash: {:?}", checkpoint_script_hash);
                     update_delegate_at_cell(
                         &delegator_identity,
                         &delegate_at_lock_hash,
@@ -141,78 +141,79 @@ pub fn update_delegate_at_cell(
         return Err(Error::InputOutputAtAmountNotEqual);
     }
 
-    let (input_amount, input_delegate_at_data) =
+    let (input_delegate_at_amount, input_delegate_at_data) =
         get_delegate_at_data_by_lock_hash(&delegate_at_lock_hash, Source::Input)?;
-    let (output_amount, output_delegate_at_data) =
+    let (output_delegate_at_amount, output_delegate_at_data) =
         get_delegate_at_data_by_lock_hash(&delegate_at_lock_hash, Source::Output)?;
     if input_delegate_at_data.version() != output_delegate_at_data.version()
         || input_delegate_at_data.metadata_type_id() != output_delegate_at_data.metadata_type_id()
     {
         return Err(Error::UpdateDataError);
     }
-    debug!(
-        "input_amount: {}, output_amount: {}",
-        input_amount, output_amount
-    );
 
     let epoch = get_current_epoch(checkpoint_type_id)?;
-    // debug!("epoch: {}", epoch);
-    let mut at_change = 0i128;
+    debug!(
+        "input_delegate_at_amount: {}, output_delegate_at_amount: {}, epoch: {}",
+        input_delegate_at_amount, output_delegate_at_amount, epoch
+    );
+
+    let mut delegate_at_change = 0i128;
     let input_delegate_info_deltas = input_delegate_at_data.delegator_infos();
     let output_delegate_info_deltas = output_delegate_at_data.delegator_infos();
     for i in 0..output_delegate_info_deltas.len() {
         let output_delegate_info = output_delegate_info_deltas.get(i);
         let output_delegate = bytes_to_u128(&output_delegate_info.amount());
         let output_increase: bool = output_delegate_info.is_increase() == 1;
-        let output_inaugutation_epoch = output_delegate_info.inauguration_epoch();
+        let output_inauguration_epoch = output_delegate_info.inauguration_epoch();
         let staker = output_delegate_info.staker();
         if staker == *delegator_identity {
             return Err(Error::DelegateSelf);
         }
-        if output_inaugutation_epoch != epoch + 2 {
+        if output_inauguration_epoch != epoch + 2 {
             return Err(Error::BadInaugurationEpoch);
         }
 
         let mut input_delegate = 0u128;
         let mut input_increase = true;
-        let mut first_delegate = true;
         for i in 0..input_delegate_info_deltas.len() {
             let input_delegate_info = input_delegate_info_deltas.get(i);
             if input_delegate_info.staker().as_slice().to_vec() == staker {
-                first_delegate = false;
                 input_delegate = bytes_to_u128(&input_delegate_info.amount());
                 input_increase = input_delegate_info.is_increase() == 1;
                 break;
             }
         }
 
-        if first_delegate {
-            // no delegate info before
-            if !output_increase {
-                return Err(Error::FirstRedeemError);
-            }
-            at_change -= output_delegate as i128; // decrease by output_delegate
-        } else {
-            // update existing delegate info
-            if input_increase {
-                if output_increase {
-                    at_change += output_delegate as i128 - input_delegate as i128;
-                } else {
-                    // delegate decrease by input_delegate, withdraw all of previous tokens
-                    at_change -= input_delegate as i128;
-                    // we should check output_delegate is less than amount stored in smt?
-                }
+        if input_increase {
+            if output_increase {
+                delegate_at_change += output_delegate as i128 - input_delegate as i128;
             } else {
-                if output_increase {
-                    at_change += output_delegate as i128;
-                } else {
-                    // we should check output_delegate is less than amount stored in smt?
-                }
+                // delegate decrease by input_delegate, withdraw all of previous tokens
+                delegate_at_change -= input_delegate as i128;
+                // we should check output_delegate is less than amount stored in smt?
+            }
+        } else {
+            if output_increase {
+                delegate_at_change += output_delegate as i128;
+            } else {
+                // we should check output_delegate is less than amount stored in smt?
             }
         }
-        if input_amount as i128 + at_change != output_amount as i128 {
-            return Err(Error::BadDelegateChange);
+
+        // can not undelegate total delegate at amount
+        if !output_increase {
+            if output_delegate > input_delegate_at_amount {
+                return Err(Error::UnDelegateTooMuch);
+            }
         }
+    }
+
+    debug!(
+        "input_delegate_at_amount: {}, delegate_at_change: {}, output_delegate_at_amount: {}",
+        input_delegate_at_amount, delegate_at_change, output_delegate_at_amount
+    );
+    if input_delegate_at_amount as i128 + delegate_at_change != output_delegate_at_amount as i128 {
+        return Err(Error::BadDelegateChange);
     }
 
     Ok(())

--- a/contracts/delegate/src/entry.rs
+++ b/contracts/delegate/src/entry.rs
@@ -202,7 +202,7 @@ pub fn update_delegate_at_cell(
 
         // can not undelegate total delegate at amount
         if !output_increase {
-            if output_delegate > input_delegate_at_amount {
+            if output_delegate > output_delegate_at_amount {
                 return Err(Error::UnDelegateTooMuch);
             }
         }

--- a/tests/src/delegate.rs
+++ b/tests/src/delegate.rs
@@ -14,7 +14,10 @@ use ckb_testtool::{builtin::ALWAYS_SUCCESS, context::Context};
 use helper::*;
 use molecule::prelude::*;
 use util::{
-    error::Error::{DelegateSelf, InputOutputAtAmountNotEqual, UnDelegateTooMuch},
+    error::Error::{
+        DelegateSelf, DelegateSmtVerifySelectionError, InputOutputAtAmountNotEqual,
+        UnDelegateTooMuch,
+    },
     smt::LockInfo,
 };
 
@@ -516,7 +519,7 @@ fn test_delegate_self_fail() {
 }
 
 #[test]
-fn test_undelegate_at_fail_too_much() {
+fn test_undelegate_at_fail_too_much_at() {
     // init context
     let mut context = Context::default();
     let delegator_keypair = Generator::random_keypair();
@@ -764,11 +767,8 @@ fn test_undelegate_at_success_stale_decrease_decrease_less() {
     println!("consume cycles: {}", cycles);
 }
 
-#[test]
-fn test_delegate_smt_redeem_success() {
-    // init context
-    let mut context = Context::default();
-
+// common tx for update undelegate tx to delegate smt cells
+fn construct_delegate_smt_undelegate_tx(context: &mut Context) -> TransactionView {
     let at_contract_bin: Bytes = Loader::default().load_binary("delegate");
     let at_contract_out_point = context.deploy_cell(at_contract_bin);
     let at_contract_dep = CellDep::new_builder()
@@ -866,11 +866,6 @@ fn test_delegate_smt_redeem_success() {
         inauguration_epoch,
     );
 
-    // let withdraw_contract_bin: Bytes = Loader::default().load_binary("withdraw");
-    // let withdraw_contract_out_point = context.deploy_cell(withdraw_contract_bin);
-    // let withdraw_contract_dep = CellDep::new_builder()
-    //     .out_point(withdraw_contract_out_point.clone())
-    //     .build();
     let withdraw_lock_args = WithdrawArgs::new_builder()
         .addr(axon_identity(&delegator_keypair.1.serialize()))
         .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
@@ -909,7 +904,7 @@ fn test_delegate_smt_redeem_success() {
             &metadata_type_script,
             &always_success_out_point,
             &always_success_lock_script,
-            &mut context,
+            context,
             &staker_keypair,
             &staker_addr,
         );
@@ -1117,9 +1112,14 @@ fn test_delegate_smt_redeem_success() {
         .cell_dep(stake_at_script_dep)
         .build();
     let tx = context.complete_tx(tx);
+    tx
+}
 
-    // sign tx for stake at cell (update stake at cell delta mode)
-    // let tx = sign_tx(tx, &delegator_keypair.0, 0);
+#[test]
+fn test_delegate_smt_redeem_success() {
+    // init context
+    let mut context = Context::default();
+    let tx = construct_delegate_smt_undelegate_tx(&mut context);
 
     // run
     let cycles = context
@@ -1128,11 +1128,12 @@ fn test_delegate_smt_redeem_success() {
     println!("consume cycles: {}", cycles);
 }
 
-#[test]
-fn test_delegate_smt_increase_success() {
-    // init context
-    let mut context = Context::default();
-
+fn construct_delegate_smt_delegate_tx(
+    context: &mut Context,
+    delegators: Vec<((Privkey, Pubkey), u128)>,
+    input_delegate_infos: BTreeSet<LockInfo>,
+    intend_fail: bool,
+) -> TransactionView {
     let at_contract_bin: Bytes = Loader::default().load_binary("delegate");
     let at_contract_out_point = context.deploy_cell(at_contract_bin);
     let at_contract_dep = CellDep::new_builder()
@@ -1181,40 +1182,112 @@ fn test_delegate_smt_increase_success() {
         .out_point(always_success_out_point.clone())
         .build();
 
-    let delegator_keypair = Generator::random_keypair();
     let staker_keypair = Generator::random_keypair();
     let staker_addr = pubkey_to_addr(&staker_keypair.1.serialize());
     println!(
         "staker pubkey: {:?}",
         blake160(&staker_keypair.1.serialize())
     );
-    let current_epoch = 1u64;
-    let delegate_amount = 1000 as u128;
-    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
-        .is_increase(1.into())
-        .amount(axon_u128(delegate_amount))
-        .inauguration_epoch(axon_u64(current_epoch + 2))
-        .staker(axon_identity(&staker_keypair.1.serialize()))
-        .build();
-    let input_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
-        .set(vec![input_delegate_info_delta.clone()])
-        .build();
-    let input_delegate_at_data = axon_delegate_at_cell_data_without_amount(
-        0,
-        &delegator_keypair.1.serialize(),
-        &delegator_keypair.1.serialize(),
-        &metadata_type_script.calc_script_hash(),
-        input_delegate_info_deltas,
-    );
 
-    // prepare delegate at lock_script
-    let delegate_at_args = delegate::DelegateArgs::new_builder()
-        .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
-        .delegator_addr(axon_identity(&delegator_keypair.1.serialize()))
-        .build();
-    let delegate_at_lock_script = context
-        .build_script(&at_contract_out_point, delegate_at_args.as_bytes())
-        .expect("delegate script");
+    let current_epoch = 1u64;
+    let mut inputs = Vec::new();
+    let mut outputs = Vec::new();
+    let mut output_datas = Vec::new();
+    let mut output_delegate_infos = BTreeSet::new();
+    let mut witnesses = Vec::new();
+    for delegator in delegators {
+        let delegator_keypair = delegator.0;
+        let delegate_amount = delegator.1;
+        let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+            .is_increase(1.into())
+            .amount(axon_u128(delegate_amount))
+            .inauguration_epoch(axon_u64(current_epoch + 2))
+            .staker(axon_identity(&staker_keypair.1.serialize()))
+            .build();
+        let input_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
+            .set(vec![input_delegate_info_delta.clone()])
+            .build();
+        let input_delegate_at_data = axon_delegate_at_cell_data_without_amount(
+            0,
+            &delegator_keypair.1.serialize(),
+            &delegator_keypair.1.serialize(),
+            &metadata_type_script.calc_script_hash(),
+            input_delegate_info_deltas,
+        );
+        let input_delegate_at_data = Bytes::from(axon_delegate_at_cell_data(
+            delegate_amount,
+            input_delegate_at_data,
+        ));
+
+        // prepare delegate at lock_script
+        let delegate_at_args = delegate::DelegateArgs::new_builder()
+            .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
+            .delegator_addr(axon_identity(&delegator_keypair.1.serialize()))
+            .build();
+        let delegate_at_lock_script = context
+            .build_script(&at_contract_out_point, delegate_at_args.as_bytes())
+            .expect("delegate script");
+
+        let input_delegate_at_cell = CellInput::new_builder()
+            .previous_output(
+                context.create_cell(
+                    CellOutput::new_builder()
+                        .capacity(1000.pack())
+                        .lock(delegate_at_lock_script.clone())
+                        .type_(Some(delegate_at_type_script.clone()).pack())
+                        .build(),
+                    input_delegate_at_data.clone(),
+                ),
+            )
+            .build();
+        inputs.push(input_delegate_at_cell);
+
+        // the 1st record is the lowest, so not selected
+        if !intend_fail && delegate_amount > 1000 {
+            let output_delegate_at_cell = CellOutput::new_builder()
+                .capacity(1000.pack())
+                .lock(delegate_at_lock_script.clone())
+                .type_(Some(delegate_at_type_script.clone()).pack())
+                .build();
+            outputs.push(output_delegate_at_cell);
+
+            let output_delegate_info_deltas: DelegateInfoDeltas =
+                DelegateInfoDeltas::new_builder().build();
+            let output_delegate_at_data = axon_delegate_at_cell_data_without_amount(
+                0,
+                &delegator_keypair.1.serialize(),
+                &delegator_keypair.1.serialize(),
+                &metadata_type_script.calc_script_hash(),
+                output_delegate_info_deltas,
+            );
+            let output_delegate_at_data = Bytes::from(axon_delegate_at_cell_data(
+                delegate_amount,
+                output_delegate_at_data,
+            )); // delegate at cell
+            output_datas.push(output_delegate_at_data);
+
+            let delegate_addr = pubkey_to_addr(&delegator_keypair.1.serialize());
+            let output_delegate_info = LockInfo {
+                addr: delegate_addr,
+                amount: delegate_amount,
+            };
+            output_delegate_infos.insert(output_delegate_info);
+        } else {
+            let output_delegate_at_cell = CellOutput::new_builder()
+                .capacity(1000.pack())
+                .lock(delegate_at_lock_script.clone())
+                .type_(Some(delegate_at_type_script.clone()).pack())
+                .build();
+            outputs.push(output_delegate_at_cell);
+            output_datas.push(input_delegate_at_data);
+        }
+
+        let delegate_at_witness = DelegateAtWitness::new_builder().mode(1.into()).build();
+        let delegate_at_witness = WitnessArgs::new_builder()
+            .lock(Some(Bytes::from(delegate_at_witness.as_bytes())).pack())
+            .build();
+        witnesses.push(delegate_at_witness.as_bytes().pack());
+    }
 
     // let delegate_smt_args = delegate::DelegateArgs::new_builder()
     //     .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
@@ -1227,9 +1300,8 @@ fn test_delegate_smt_increase_success() {
             Bytes::from(vec![3u8; 32]),
         )
         .expect("delegate smt type script");
-    let delegate_infos = BTreeSet::new();
     let (input_delegate_smt_cell_data, input_delegate_epoch_proof) = axon_delegate_smt_cell_data(
-        &delegate_infos,
+        &input_delegate_infos,
         &metadata_type_script.calc_script_hash(),
         &staker_keypair.1,
         current_epoch + 2,
@@ -1240,26 +1312,13 @@ fn test_delegate_smt_increase_success() {
             &metadata_type_script,
             &always_success_out_point,
             &always_success_lock_script,
-            &mut context,
+            context,
             &staker_keypair,
             &staker_addr,
         );
 
     // prepare tx inputs and outputs
-    let inputs = vec![
-        // delegate AT cell
-        CellInput::new_builder()
-            .previous_output(
-                context.create_cell(
-                    CellOutput::new_builder()
-                        .capacity(1000.pack())
-                        .lock(delegate_at_lock_script.clone())
-                        .type_(Some(delegate_at_type_script.clone()).pack())
-                        .build(),
-                    Bytes::from(axon_delegate_at_cell_data(1000, input_delegate_at_data)),
-                ),
-            )
-            .build(),
+    inputs.push(
         // delegate smt cell
         CellInput::new_builder()
             .previous_output(
@@ -1273,50 +1332,96 @@ fn test_delegate_smt_increase_success() {
                 ),
             )
             .build(),
-    ];
-    let outputs = vec![
-        // delegate at cell
-        CellOutput::new_builder()
-            .capacity(1000.pack())
-            .lock(delegate_at_lock_script.clone())
-            .type_(Some(delegate_at_type_script.clone()).pack())
-            .build(),
+    );
+
+    outputs.push(
         // delegate smt cell
         CellOutput::new_builder()
             .capacity(1000.pack())
             .lock(always_success_lock_script.clone())
             .type_(Some(delegate_smt_type_script.clone()).pack())
             .build(),
-    ];
-
-    // prepare outputs_data
-    let output_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder().build();
-    let output_delegate_at_data = axon_delegate_at_cell_data_without_amount(
-        0,
-        &delegator_keypair.1.serialize(),
-        &delegator_keypair.1.serialize(),
-        &metadata_type_script.calc_script_hash(),
-        output_delegate_info_deltas,
     );
 
-    let delegate_addr = pubkey_to_addr(&delegator_keypair.1.serialize());
-    let output_delegate_infos = BTreeSet::from_iter(vec![LockInfo {
-        addr: delegate_addr,
-        amount: delegate_amount,
-    }]);
     let (output_delegate_smt_cell_data, output_delegate_epoch_proof) = axon_delegate_smt_cell_data(
         &output_delegate_infos,
         &metadata_type_script.calc_script_hash(),
         &staker_keypair.1,
         current_epoch + 2,
     );
+    output_datas.push(
+        output_delegate_smt_cell_data.as_bytes(), // delegate smt cell
+    );
 
-    let outputs_data = vec![
-        Bytes::from(axon_delegate_at_cell_data(1000, output_delegate_at_data)), // delegate at cell
-        output_delegate_smt_cell_data.as_bytes(),                               // delegate smt cell
-                                                                                // Bytes::from(axon_withdrawal_data(50, 2)),
-    ];
+    // this indicates the specific case to withdraw AT updated to smt
+    if input_delegate_infos.len() > 0 {
+        // input_delegate_infos contains only 1 that needs withdraw
+        let withdraw_lock_args = WithdrawArgs::new_builder()
+            .addr(axon_byte20_identity(
+                &input_delegate_infos.first().unwrap().addr,
+            ))
+            .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
+            .build();
+        let withdraw_lock_script = context
+            .build_script_with_hash_type(
+                &always_success_out_point,
+                ScriptHashType::Type,
+                withdraw_lock_args.as_bytes(),
+            )
+            .expect("withdraw lock script");
+        println!(
+            "withdraw_lock_script code hash: {:?}, addr: {:?}, metadata_type_id: {:?}, args: {:?}",
+            withdraw_lock_script.code_hash().as_slice(),
+            axon_byte20_identity(&input_delegate_infos.first().unwrap().addr).as_slice(),
+            metadata_type_script.calc_script_hash().as_slice(),
+            withdraw_lock_args.as_slice()
+        );
+        let input_withdraw_infos = vec![
+            (current_epoch, 0 as u128),
+            (current_epoch + 1, 0),
+            (current_epoch + 2, 0),
+        ];
+        let input_withdraw_data = axon_withdraw_at_cell_data_without_amount(input_withdraw_infos);
+        let input_withdraw_out_point = context.create_cell(
+            CellOutput::new_builder()
+                .capacity(1000.pack())
+                .lock(withdraw_lock_script.clone())
+                .type_(Some(delegate_at_type_script.clone()).pack())
+                .build(),
+            Bytes::from(axon_withdraw_at_cell_data(0, input_withdraw_data)), // delegate at cell
+        );
 
+        inputs.push(
+            // withdraw at cell
+            CellInput::new_builder()
+                .previous_output(input_withdraw_out_point)
+                .build(),
+        );
+        outputs.push(
+            // withdraw at cell
+            CellOutput::new_builder()
+                .capacity(1000.pack())
+                .lock(withdraw_lock_script.clone())
+                .type_(Some(delegate_at_type_script.clone()).pack())
+                .build(),
+        );
+        let output_withdraw_infos = vec![
+            (current_epoch, 0 as u128),
+            (current_epoch + 1, 0),
+            (
+                current_epoch + 2,
+                input_delegate_infos.first().unwrap().amount,
+            ),
+        ];
+        let output_withdraw_data = axon_withdraw_at_cell_data_without_amount(output_withdraw_infos);
+        let output_withdraw_data = Bytes::from(axon_withdraw_at_cell_data(
+            input_delegate_infos.first().unwrap().amount,
+            output_withdraw_data,
+        )); // withdraw at cell
+        output_datas.push(
+            output_withdraw_data, // delegate smt cell
+        );
+    }
     // prepare metadata cell_dep
     let metadata = Metadata::new_builder().epoch_len(axon_u32(100)).build();
     let metadata_list = MetadataList::new_builder().push(metadata).build();
@@ -1328,6 +1433,9 @@ fn test_delegate_smt_increase_success() {
             .as_bytes()
             .to_vec()
     );
+    let delegate_at_lock_script = context
+        .build_script(&at_contract_out_point, Bytes::from(vec![9u8]))
+        .expect("delegate script");
     let meta_data = axon_metadata_data_by_script(
         &metadata_type_script.clone(),
         &delegate_at_type_script.calc_script_hash(),
@@ -1371,12 +1479,15 @@ fn test_delegate_smt_increase_success() {
         )
         .build();
 
-    let _delegate_info = DelegateInfo::new_builder()
-        .amount(axon_u128(1000))
-        .delegator_addr(axon_identity(&delegator_keypair.1.serialize()))
-        .build();
-    // let delegate_infos = DelegateInfos::new_builder().push(delegate_info).build();
-    let delegate_infos = DelegateInfos::new_builder().build();
+    let mut delegate_infos = Vec::new();
+    for info in input_delegate_infos {
+        let delegate_info = DelegateInfo::new_builder()
+            .amount(axon_u128(info.amount))
+            .delegator_addr(axon_byte20_identity(&info.addr))
+            .build();
+        delegate_infos.push(delegate_info)
+    }
+    let delegate_infos = DelegateInfos::new_builder().set(delegate_infos).build();
     let stake_group_info = StakeGroupInfo::new_builder()
         .staker(axon_identity(&staker_keypair.1.serialize()))
         .delegate_infos(delegate_infos)
@@ -1395,11 +1506,6 @@ fn test_delegate_smt_increase_success() {
         delegate_smt_update_info.as_bytes().len()
     );
 
-    let delegate_at_witness = DelegateAtWitness::new_builder().mode(1.into()).build();
-    let delegate_at_witness = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(delegate_at_witness.as_bytes())).pack())
-        .build();
-
     let delegate_smt_witness = DelegateSmtWitness::new_builder()
         .mode(0.into())
         .update_info(delegate_smt_update_info)
@@ -1407,16 +1513,14 @@ fn test_delegate_smt_increase_success() {
     let delegate_smt_witness = WitnessArgs::new_builder()
         .input_type(Some(Bytes::from(delegate_smt_witness.as_bytes())).pack())
         .build();
+    witnesses.push(delegate_smt_witness.as_bytes().pack());
 
     // prepare signed tx
     let tx = TransactionBuilder::default()
         .inputs(inputs)
         .outputs(outputs)
-        .outputs_data(outputs_data.pack())
-        .witnesses(vec![
-            delegate_at_witness.as_bytes().pack(),
-            delegate_smt_witness.as_bytes().pack(),
-        ])
+        .outputs_data(output_datas.pack())
+        .witnesses(witnesses)
         .cell_dep(at_contract_dep)
         .cell_dep(smt_contract_dep)
         .cell_dep(always_success_script_dep)
@@ -1426,15 +1530,130 @@ fn test_delegate_smt_increase_success() {
         .cell_dep(stake_at_script_dep)
         .build();
     let tx = context.complete_tx(tx);
+    tx
+}
 
-    // sign tx for stake at cell (update stake at cell delta mode)
-    // let tx = sign_tx(tx, &delegator_keypair.0, 0);
+#[test]
+fn test_delegate_smt_increase_success() {
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    // must larger than 1000, to simpilfy test
+    let delegate_amount = 2000 as u128;
+    let delegator_keypair1 = Generator::random_keypair();
+    let delegate_amount1 = 2000 as u128;
+
+    let input_delegate_infos = BTreeSet::new();
+
+    let delegators = vec![
+        (delegator_keypair, delegate_amount),
+        (delegator_keypair1, delegate_amount1),
+    ];
+    let tx =
+        construct_delegate_smt_delegate_tx(&mut context, delegators, input_delegate_infos, false);
 
     // run
     let cycles = context
         .verify_tx(&tx, MAX_CYCLES)
         .expect("pass verification");
     println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_smt_increase_success_toomany_delegator() {
+    // we need to delete 1 delegator out of 4, because only 3 delegator is allowed for every staker
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let delegate_amount = 1000 as u128;
+    let delegator_keypair1 = Generator::random_keypair();
+    let delegate_amount1 = 2000 as u128;
+    let delegator_keypair2 = Generator::random_keypair();
+    let delegate_amount2 = 3000 as u128;
+    let delegator_keypair3 = Generator::random_keypair();
+    let delegate_amount3 = 4000 as u128;
+    let input_delegate_infos = BTreeSet::new();
+
+    let delegators = vec![
+        (delegator_keypair, delegate_amount),
+        (delegator_keypair1, delegate_amount1),
+        (delegator_keypair2, delegate_amount2),
+        (delegator_keypair3, delegate_amount3),
+    ];
+    let tx =
+        construct_delegate_smt_delegate_tx(&mut context, delegators, input_delegate_infos, false);
+
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_smt_increase_success_toomany_delegator_withdraw() {
+    // we need to delete 1 delegator out of 4, because only 3 delegator is allowed for every staker
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let delegate_amount = 500 as u128;
+    let delegator_keypair1 = Generator::random_keypair();
+    let delegate_amount1 = 2000 as u128;
+    let delegator_keypair2 = Generator::random_keypair();
+    let delegate_amount2 = 3000 as u128;
+    let delegator_keypair3 = Generator::random_keypair();
+    let delegate_amount3 = 4000 as u128;
+    let input_delegate_infos = BTreeSet::from_iter(vec![LockInfo {
+        addr: pubkey_to_addr(&delegator_keypair.1.serialize()),
+        amount: 600,
+    }]);
+
+    let delegators = vec![
+        (delegator_keypair, delegate_amount),
+        (delegator_keypair1, delegate_amount1),
+        (delegator_keypair2, delegate_amount2),
+        (delegator_keypair3, delegate_amount3),
+    ];
+    let tx =
+        construct_delegate_smt_delegate_tx(&mut context, delegators, input_delegate_infos, false);
+
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_smt_increase_fail_toomany_delegator_not() {
+    // we need to delete 1 delegator out of 4, because only 3 delegator is allowed for every staker
+    // this time, we did not delete it
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let delegate_amount = 1000 as u128;
+    let delegator_keypair1 = Generator::random_keypair();
+    let delegate_amount1 = 2000 as u128;
+    let delegator_keypair2 = Generator::random_keypair();
+    let delegate_amount2 = 3000 as u128;
+    let delegator_keypair3 = Generator::random_keypair();
+    let delegate_amount3 = 4000 as u128;
+    let input_delegate_infos = BTreeSet::new();
+
+    let delegators = vec![
+        (delegator_keypair, delegate_amount),
+        (delegator_keypair1, delegate_amount1),
+        (delegator_keypair2, delegate_amount2),
+        (delegator_keypair3, delegate_amount3),
+    ];
+    let tx =
+        construct_delegate_smt_delegate_tx(&mut context, delegators, input_delegate_infos, true);
+
+    // run
+    let err = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect_err("DelegateSmtVerifySelectionError");
+    assert_script_error(err, DelegateSmtVerifySelectionError as i8);
 }
 
 #[test]
@@ -1469,10 +1688,6 @@ fn test_delegate_smt_create_success() {
         .build();
 
     let input_hash = calc_type_id(&input, 0);
-    // let input_hash = {
-    //     let ret = [0; 32];
-    //     Bytes::from(ret.to_vec())
-    // };
     let delegate_smt_type_script = context
         .build_script(&smt_contract_out_point, input_hash)
         .expect("delegate smt type script");
@@ -1705,7 +1920,7 @@ fn test_delegate_requirement_success() {
         .out_point(always_success_out_point.clone())
         .build();
 
-    let delegate_cell_data = axon_delegate_requirement_cell_data(10);
+    let delegate_cell_data = axon_delegate_requirement_cell_data(10, 3);
 
     // prepare tx inputs and outputs
     let input = CellInput::new_builder()

--- a/tests/src/delegate.rs
+++ b/tests/src/delegate.rs
@@ -5,18 +5,60 @@ use super::*;
 use axon_types::delegate::*;
 use axon_types::metadata::{Metadata, MetadataList};
 use axon_types::withdraw::WithdrawArgs;
-use ckb_testtool::ckb_crypto::secp::Generator;
+use ckb_testtool::ckb_crypto::secp::{Generator, Privkey, Pubkey};
 use ckb_testtool::ckb_types::core::ScriptHashType;
-use ckb_testtool::ckb_types::{bytes::Bytes, core::TransactionBuilder, packed::*, prelude::*};
+use ckb_testtool::ckb_types::{
+    bytes::Bytes, core::TransactionBuilder, core::TransactionView, packed::*, prelude::*,
+};
 use ckb_testtool::{builtin::ALWAYS_SUCCESS, context::Context};
 use helper::*;
 use molecule::prelude::*;
-use util::{error::Error::DelegateSelf, smt::LockInfo};
+use util::{
+    error::Error::{DelegateSelf, InputOutputAtAmountNotEqual},
+    smt::LockInfo,
+};
 
-#[test]
-fn test_delegate_at_increase_success() {
-    // init context
-    let mut context = Context::default();
+// newly added delegate info
+fn construct_delegate_tx(context: &mut Context) -> TransactionView {
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = Generator::random_keypair();
+    // let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+    //     .staker(axon_identity(&staker_keypair.1.serialize()))
+    //     .build();
+    let output_at_amount = 1000;
+    let output_delegate_at_amount = 100;
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(output_delegate_at_amount))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+
+    construct_delegate_tx_with_args(
+        context,
+        delegator_keypair,
+        None,
+        output_delegate_info_delta,
+        output_at_amount,
+        0,
+        output_at_amount - output_delegate_at_amount,
+        output_delegate_at_amount,
+    )
+}
+
+fn construct_delegate_tx_with_args(
+    context: &mut Context,
+    delegator_keypair: (Privkey, Pubkey),
+    input_delegate_info_delta: Option<delegate::DelegateInfoDelta>,
+    output_delegate_info_delta: delegate::DelegateInfoDelta,
+    input_normal_at_amount: u128,
+    input_delegate_at_amount: u128,
+    output_normal_at_amount: u128,
+    output_delegate_at_amount: u128,
+) -> TransactionView {
+    // let input_normal_at_amount: u128 = 1000;
+    // let output_normal_at_amount: u128 = 900;
+    let current_epoch = 1;
 
     let contract_bin: Bytes = Loader::default().load_binary("delegate");
     let contract_out_point = context.deploy_cell(contract_bin);
@@ -53,19 +95,20 @@ fn test_delegate_at_increase_success() {
         .out_point(always_success_out_point.clone())
         .build();
 
-    let delegator_keypair = Generator::random_keypair();
     let delegate_args = delegate::DelegateArgs::new_builder()
         .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
         .delegator_addr(axon_identity(&delegator_keypair.1.serialize()))
         .build();
 
-    let staker_keypair = Generator::random_keypair();
-    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
-        .staker(axon_identity(&staker_keypair.1.serialize()))
-        .build();
-    let input_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
-        .set(vec![input_delegate_info_delta.clone()])
-        .build();
+    let input_delegate_info_deltas =
+        if let Some(input_delegate_info_delta) = input_delegate_info_delta {
+            DelegateInfoDeltas::new_builder()
+                .push(input_delegate_info_delta)
+                .build()
+        } else {
+            DelegateInfoDeltas::new_builder().build()
+        };
+
     let input_delegate_at_data = axon_delegate_at_cell_data_without_amount(
         0,
         &delegator_keypair.1.serialize(),
@@ -90,7 +133,10 @@ fn test_delegate_at_increase_success() {
                         .lock(delegate_at_lock_script.clone())
                         .type_(Some(delegate_at_type_script.clone()).pack())
                         .build(),
-                    Bytes::from(axon_delegate_at_cell_data(0, input_delegate_at_data)),
+                    Bytes::from(axon_delegate_at_cell_data(
+                        input_delegate_at_amount,
+                        input_delegate_at_data,
+                    )),
                 ),
             )
             .build(),
@@ -103,7 +149,7 @@ fn test_delegate_at_increase_success() {
                         .lock(always_success_lock_script.clone())
                         .type_(Some(delegate_at_type_script.clone()).pack())
                         .build(),
-                    Bytes::from((1000 as u128).to_le_bytes().to_vec()),
+                    Bytes::from((input_normal_at_amount).to_le_bytes().to_vec()),
                 ),
             )
             .build(),
@@ -124,12 +170,6 @@ fn test_delegate_at_increase_success() {
     ];
 
     // prepare outputs_data
-    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
-        .is_increase(1.into())
-        .amount(axon_u128(100 as u128))
-        .inauguration_epoch(axon_u64(3 as u64))
-        .staker(axon_identity(&staker_keypair.1.serialize()))
-        .build();
     let output_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
         .set(vec![output_delegate_info_delta.clone()])
         .build();
@@ -142,9 +182,12 @@ fn test_delegate_at_increase_success() {
     );
 
     let outputs_data = vec![
-        Bytes::from(axon_delegate_at_cell_data(100, output_delegate_at_data)), // stake at cell
-        Bytes::from((900 as u128).to_le_bytes().to_vec()),                     // normal at cell
-                                                                               // Bytes::from(axon_withdrawal_data(50, 2)),
+        Bytes::from(axon_delegate_at_cell_data(
+            output_delegate_at_amount,
+            output_delegate_at_data,
+        )), // stake at cell
+        Bytes::from((output_normal_at_amount).to_le_bytes().to_vec()), // normal at cell
+                                                                       // Bytes::from(axon_withdrawal_data(50, 2)),
     ];
 
     // prepare metadata cell_dep
@@ -158,7 +201,7 @@ fn test_delegate_at_increase_success() {
         &delegate_at_type_script, // needless here
         &delegate_at_type_script, // needless here
         metadata_list,
-        1,
+        current_epoch,
         100,
         100,
         propose_count_smt_root,
@@ -179,7 +222,10 @@ fn test_delegate_at_increase_success() {
         )
         .build();
     // prepare checkpoint cell_dep
-    let checkpoint_data = axon_checkpoint_data(&metadata_type_script.clone().calc_script_hash(), 1);
+    let checkpoint_data = axon_checkpoint_data(
+        &metadata_type_script.clone().calc_script_hash(),
+        current_epoch,
+    );
     println!("checkpoint data: {:?}", checkpoint_data.as_bytes().len());
     let checkpoint_script_dep = CellDep::new_builder()
         .out_point(
@@ -215,9 +261,14 @@ fn test_delegate_at_increase_success() {
         .cell_dep(metadata_script_dep)
         .build();
     let tx = context.complete_tx(tx);
+    tx
+}
 
-    // sign tx for delegate at cell (update stake at cell delta mode)
-    // let tx = sign_tx(tx, &delegator_keypair.0, 0);
+#[test]
+fn test_delegate_at_success_add_new() {
+    // init context
+    let mut context = Context::default();
+    let tx = construct_delegate_tx(&mut context);
 
     // run
     let cycles = context
@@ -227,207 +278,235 @@ fn test_delegate_at_increase_success() {
 }
 
 #[test]
-fn test_delegate_self_fail() {
+fn test_delegate_at_success_increase_existing() {
     // init context
     let mut context = Context::default();
-
-    let contract_bin: Bytes = Loader::default().load_binary("delegate");
-    let contract_out_point = context.deploy_cell(contract_bin);
-    let contract_dep = CellDep::new_builder()
-        .out_point(contract_out_point.clone())
-        .build();
-    let always_success_out_point = context.deploy_cell(ALWAYS_SUCCESS.clone());
-    let always_success_lock_script = context
-        .build_script(&always_success_out_point, Bytes::from(vec![1]))
-        .expect("always_success script");
-    let checkpoint_type_script = context
-        .build_script_with_hash_type(
-            &always_success_out_point,
-            ScriptHashType::Type,
-            Bytes::from(vec![2u8; 32]),
-        )
-        .expect("checkpoint script");
-    println!(
-        "checkpoint type script: {:?}",
-        checkpoint_type_script.calc_script_hash()
-    );
-
-    let delegate_at_type_script = context
-        .build_script(&always_success_out_point, Bytes::from(vec![4]))
-        .expect("sudt script");
-    let metadata_type_script = context
-        .build_script_with_hash_type(
-            &always_success_out_point,
-            ScriptHashType::Type,
-            Bytes::from(vec![5]),
-        )
-        .expect("metadata type script");
-    let always_success_script_dep = CellDep::new_builder()
-        .out_point(always_success_out_point.clone())
-        .build();
-
     let delegator_keypair = Generator::random_keypair();
-    let delegate_args = delegate::DelegateArgs::new_builder()
-        .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
-        .delegator_addr(axon_identity(&delegator_keypair.1.serialize()))
-        .build();
+    let staker_keypair = Generator::random_keypair();
+    let input_normal_at_amount = 1000;
+    let input_delegate_at_amount = 100;
+    let output_normal_at_amount = 900;
+    let output_delegate_at_amount = 200;
 
-    let staker_keypair = delegator_keypair.clone();
     let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
-        .staker(axon_identity(&staker_keypair.1.serialize()))
-        .build();
-    let input_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
-        .set(vec![input_delegate_info_delta.clone()])
-        .build();
-    let input_delegate_at_data = axon_delegate_at_cell_data_without_amount(
-        0,
-        &delegator_keypair.1.serialize(),
-        &delegator_keypair.1.serialize(),
-        &metadata_type_script.calc_script_hash(),
-        input_delegate_info_deltas,
-    );
-
-    // prepare stake lock_script
-    let delegate_at_lock_script = context
-        .build_script(&contract_out_point, delegate_args.as_bytes())
-        .expect("stake script");
-
-    // prepare tx inputs and outputs
-    let inputs = vec![
-        // delegate AT cell
-        CellInput::new_builder()
-            .previous_output(
-                context.create_cell(
-                    CellOutput::new_builder()
-                        .capacity(1000.pack())
-                        .lock(delegate_at_lock_script.clone())
-                        .type_(Some(delegate_at_type_script.clone()).pack())
-                        .build(),
-                    Bytes::from(axon_delegate_at_cell_data(0, input_delegate_at_data)),
-                ),
-            )
-            .build(),
-        // normal AT cell
-        CellInput::new_builder()
-            .previous_output(
-                context.create_cell(
-                    CellOutput::new_builder()
-                        .capacity(1000.pack())
-                        .lock(always_success_lock_script.clone())
-                        .type_(Some(delegate_at_type_script.clone()).pack())
-                        .build(),
-                    Bytes::from((1000 as u128).to_le_bytes().to_vec()),
-                ),
-            )
-            .build(),
-    ];
-    let outputs = vec![
-        // delegate at cell
-        CellOutput::new_builder()
-            .capacity(1000.pack())
-            .lock(delegate_at_lock_script.clone())
-            .type_(Some(delegate_at_type_script.clone()).pack())
-            .build(),
-        // normal at cell
-        CellOutput::new_builder()
-            .capacity(1000.pack())
-            .lock(always_success_lock_script.clone())
-            .type_(Some(delegate_at_type_script.clone()).pack())
-            .build(),
-    ];
-
-    // prepare outputs_data
-    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
         .is_increase(1.into())
-        .amount(axon_u128(100 as u128))
+        .amount(axon_u128(input_delegate_at_amount))
         .inauguration_epoch(axon_u64(3 as u64))
         .staker(axon_identity(&staker_keypair.1.serialize()))
         .build();
-    let output_delegate_info_deltas: DelegateInfoDeltas = DelegateInfoDeltas::new_builder()
-        .set(vec![output_delegate_info_delta.clone()])
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(output_delegate_at_amount))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
         .build();
-    let output_delegate_at_data = axon_delegate_at_cell_data_without_amount(
+
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        Some(input_delegate_info_delta),
+        output_delegate_info_delta,
+        input_normal_at_amount,
+        input_delegate_at_amount,
+        output_normal_at_amount,
+        output_delegate_at_amount,
+    );
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_at_success_decrease_increase_more() {
+    // existing decrease, but increase more at
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = Generator::random_keypair();
+    let delegate_amount = 200;
+    let input_normal_at_amount = 1000;
+    let input_delegate_at_amount = 100;
+    let output_normal_at_amount = 800;
+    let output_delegate_at_amount = input_delegate_at_amount + delegate_amount;
+
+    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(0.into())
+        .amount(axon_u128(300))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(delegate_amount))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        Some(input_delegate_info_delta),
+        output_delegate_info_delta,
+        input_normal_at_amount,
+        input_delegate_at_amount,
+        output_normal_at_amount,
+        output_delegate_at_amount,
+    );
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_at_success_stale_increase_increase() {
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = Generator::random_keypair();
+    let input_normal_at_amount = 1000;
+    let input_delegate_at_amount = 100;
+    let output_normal_at_amount = 900;
+    let output_delegate_at_amount = 200;
+
+    let waiting_epoch: u64 = 3;
+    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(input_delegate_at_amount))
+        .inauguration_epoch(axon_u64(waiting_epoch - 1))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(output_delegate_at_amount))
+        .inauguration_epoch(axon_u64(waiting_epoch))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        Some(input_delegate_info_delta),
+        output_delegate_info_delta,
+        input_normal_at_amount,
+        input_delegate_at_amount,
+        output_normal_at_amount,
+        output_delegate_at_amount,
+    );
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_at_success_stale_decrease_increase() {
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = Generator::random_keypair();
+    let input_normal_at_amount = 1000;
+    let input_delegate_at_amount = 100;
+    let output_normal_at_amount = 900;
+    let output_delegate_at_amount = 200;
+
+    let waiting_epoch: u64 = 3;
+    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(0.into())
+        .amount(axon_u128(500))
+        .inauguration_epoch(axon_u64(waiting_epoch - 1))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(
+            output_delegate_at_amount - input_delegate_at_amount,
+        ))
+        .inauguration_epoch(axon_u64(waiting_epoch))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        Some(input_delegate_info_delta),
+        output_delegate_info_delta,
+        input_normal_at_amount,
+        input_delegate_at_amount,
+        output_normal_at_amount,
+        output_delegate_at_amount,
+    );
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
+fn test_delegate_at_fail_increase_existing_more() {
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = Generator::random_keypair();
+    let input_normal_at_amount = 1000;
+    let input_delegate_at_amount = 100;
+    let output_normal_at_amount = 1000;
+    let output_delegate_at_amount = 200;
+
+    let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(input_delegate_at_amount))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(output_delegate_at_amount))
+        .inauguration_epoch(axon_u64(3 as u64))
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        Some(input_delegate_info_delta),
+        output_delegate_info_delta,
+        input_normal_at_amount,
+        input_delegate_at_amount,
+        output_normal_at_amount,
+        output_delegate_at_amount,
+    );
+    // run
+    let err = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect_err("InputOutputAtAmountNotEqual");
+    assert_script_error(err, InputOutputAtAmountNotEqual as i8);
+}
+
+#[test]
+fn test_delegate_self_fail() {
+    // init context
+    let mut context = Context::default();
+    let delegator_keypair = Generator::random_keypair();
+    let staker_keypair = delegator_keypair.clone();
+    let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
+        .staker(axon_identity(&staker_keypair.1.serialize()))
+        .build();
+    let tx = construct_delegate_tx_with_args(
+        &mut context,
+        delegator_keypair,
+        None,
+        output_delegate_info_delta,
+        1000,
         0,
-        &delegator_keypair.1.serialize(),
-        &delegator_keypair.1.serialize(),
-        &metadata_type_script.calc_script_hash(),
-        output_delegate_info_deltas,
-    );
-
-    let outputs_data = vec![
-        Bytes::from(axon_delegate_at_cell_data(100, output_delegate_at_data)), // stake at cell
-        Bytes::from((900 as u128).to_le_bytes().to_vec()),                     // normal at cell
-                                                                               // Bytes::from(axon_withdrawal_data(50, 2)),
-    ];
-
-    // prepare metadata cell_dep
-    let metadata = Metadata::new_builder().epoch_len(axon_u32(100)).build();
-    let metadata_list = MetadataList::new_builder().push(metadata).build();
-    let propose_count_smt_root = [0u8; 32];
-    let meta_data = axon_metadata_data_by_script(
-        &metadata_type_script.clone(),
-        &delegate_at_type_script.calc_script_hash(),
-        &checkpoint_type_script,
-        &delegate_at_type_script, // needless here
-        &delegate_at_type_script, // needless here
-        metadata_list,
-        1,
+        900,
         100,
-        100,
-        propose_count_smt_root,
-        &metadata_type_script.code_hash(),
-        &delegate_at_lock_script.code_hash(),
-        &metadata_type_script.code_hash(),
     );
-    let metadata_script_dep = CellDep::new_builder()
-        .out_point(
-            context.create_cell(
-                CellOutput::new_builder()
-                    .capacity(1000.pack())
-                    .lock(always_success_lock_script.clone())
-                    .type_(Some(metadata_type_script.clone()).pack())
-                    .build(),
-                meta_data.as_bytes(),
-            ),
-        )
-        .build();
-    // prepare checkpoint cell_dep
-    let checkpoint_data = axon_checkpoint_data(&metadata_type_script.clone().calc_script_hash(), 1);
-    println!("checkpoint data: {:?}", checkpoint_data.as_bytes().len());
-    let checkpoint_script_dep = CellDep::new_builder()
-        .out_point(
-            context.create_cell(
-                CellOutput::new_builder()
-                    .capacity(1000.pack())
-                    .lock(always_success_lock_script.clone())
-                    .type_(Some(checkpoint_type_script).pack())
-                    .build(),
-                checkpoint_data.as_bytes(),
-            ),
-        )
-        .build();
-
-    let delegate_at_witness = DelegateAtWitness::new_builder().mode(0.into()).build();
-    println!(
-        "delegate at witness: {:?}",
-        delegate_at_witness.as_bytes().len()
-    );
-    let delegate_at_witness = WitnessArgs::new_builder()
-        .lock(Some(Bytes::from(delegate_at_witness.as_bytes())).pack())
-        .build();
-
-    // prepare signed tx
-    let tx = TransactionBuilder::default()
-        .inputs(inputs)
-        .outputs(outputs)
-        .witness(delegate_at_witness.as_bytes().pack())
-        .outputs_data(outputs_data.pack())
-        .cell_dep(contract_dep)
-        .cell_dep(always_success_script_dep)
-        .cell_dep(checkpoint_script_dep)
-        .cell_dep(metadata_script_dep)
-        .build();
-    let tx = context.complete_tx(tx);
 
     // run
     let err = context

--- a/tests/src/delegate.rs
+++ b/tests/src/delegate.rs
@@ -25,9 +25,6 @@ use util::{
 fn construct_delegate_tx(context: &mut Context) -> TransactionView {
     let delegator_keypair = Generator::random_keypair();
     let staker_keypair = Generator::random_keypair();
-    // let input_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
-    //     .staker(axon_identity(&staker_keypair.1.serialize()))
-    //     .build();
     let output_at_amount = 1000;
     let output_delegate_at_amount = 100;
     let output_delegate_info_delta = delegate::DelegateInfoDelta::new_builder()
@@ -59,8 +56,6 @@ fn construct_delegate_tx_with_args(
     output_normal_at_amount: u128,
     output_delegate_at_amount: u128,
 ) -> TransactionView {
-    // let input_normal_at_amount: u128 = 1000;
-    // let output_normal_at_amount: u128 = 900;
     let current_epoch = 1;
 
     let contract_bin: Bytes = Loader::default().load_binary("delegate");

--- a/tests/src/helper.rs
+++ b/tests/src/helper.rs
@@ -243,10 +243,11 @@ pub fn axon_delegate_at_cell_data(
 
 pub fn axon_delegate_requirement_cell_data(
     commission_rate: u8,
+    max_delegator_size: u32,
 ) -> axon_types::delegate::DelegateCellData {
     let requirement = axon_types::delegate::DelegateRequirement::new_builder()
         .commission_rate(commission_rate.into())
-        .max_delegator_size(axon_u32(100))
+        .max_delegator_size(axon_u32(max_delegator_size))
         .build();
     axon_types::delegate::DelegateCellData::new_builder()
         .delegate_requirement(requirement)
@@ -273,7 +274,7 @@ pub fn axon_delegate_requirement_and_stake_at_cell(
             delegate_requirement_args.as_bytes(),
         )
         .expect("delegate requirement type script");
-    let delegate_requirement_cell_data = axon_delegate_requirement_cell_data(10);
+    let delegate_requirement_cell_data = axon_delegate_requirement_cell_data(10, 3);
     let delegate_requirement_script_dep = CellDep::new_builder()
         .out_point(
             context.create_cell(

--- a/tests/src/stake.rs
+++ b/tests/src/stake.rs
@@ -19,7 +19,9 @@ use helper::*;
 use molecule::prelude::*;
 use ophelia::{Crypto, PrivateKey, Signature, ToPublicKey, UncompressedPublicKey};
 use ophelia_secp256k1::{Secp256k1Recoverable, Secp256k1RecoverablePrivateKey};
-use util::error::Error::{BadInaugurationEpoch, InputOutputAtAmountNotEqual, UnstakeTooMuch, BadStakeChange};
+use util::error::Error::{
+    BadInaugurationEpoch, BadStakeChange, InputOutputAtAmountNotEqual, UnstakeTooMuch,
+};
 use util::smt::{u64_to_h256, LockInfo, BOTTOM_SMT};
 // use util::helper::pubkey_to_eth_addr;
 
@@ -553,10 +555,13 @@ fn test_stake_at_success_decrease_decrease_toomuch() {
     assert_script_error(err, UnstakeTooMuch as i8);
 }
 
-#[test]
-fn test_stake_smt_success() {
-    // init context
-    let mut context = Context::default();
+fn construct_stake_smt_tx(
+    context: &mut Context,
+    input_stake_info_delta: StakeInfoDelta,
+    output_stake_info_delta: StakeInfoDelta,
+    input_stake_at_amount: u128,
+    output_stake_at_amount: u128,
+) -> TransactionView {
     let secp256k1_data_bin = BUNDLED_CELL.get("specs/cells/secp256k1_data").unwrap();
     let secp256k1_data_out_point = context.deploy_cell(secp256k1_data_bin.to_vec().into());
     let secp256k1_data_dep = CellDep::new_builder()
@@ -611,13 +616,7 @@ fn test_stake_smt_success() {
         .stake_addr(l2_addr.clone())
         .build();
 
-    let new_stake_amount = 100;
     let inauguration_epoch = 3;
-    let input_stake_info_delta = stake::StakeInfoDelta::new_builder()
-        .is_increase(1.into())
-        .amount(axon_u128(new_stake_amount))
-        .inauguration_epoch(axon_u64(inauguration_epoch))
-        .build();
     let input_stake_at_data = axon_stake_at_cell_data_without_amount(
         0,
         &keypair.1.serialize(),
@@ -672,7 +671,10 @@ fn test_stake_smt_success() {
                         .lock(stake_at_lock_script.clone())
                         .type_(Some(stake_at_type_script.clone()).pack())
                         .build(),
-                    Bytes::from(axon_stake_at_cell_data(100, input_stake_at_data)),
+                    Bytes::from(axon_stake_at_cell_data(
+                        input_stake_at_amount,
+                        input_stake_at_data,
+                    )),
                 ),
             )
             .build(),
@@ -698,7 +700,6 @@ fn test_stake_smt_success() {
     ];
 
     // prepare outputs_data
-    let output_stake_info_delta = stake::StakeInfoDelta::new_builder().build();
     let output_stake_at_data = axon_stake_at_cell_data_without_amount(
         0,
         &keypair.1.serialize(),
@@ -711,7 +712,7 @@ fn test_stake_smt_success() {
     let lock_info = LockInfo {
         // addr: blake160(keypair.1.serialize().as_slice()),
         addr: l2_addr.as_slice().try_into().unwrap(),
-        amount: new_stake_amount,
+        amount: input_stake_at_amount,
     };
     let output_stake_infos = vec![lock_info].into_iter().collect::<BTreeSet<LockInfo>>();
     // let output_stake_infos = BTreeSet::new();
@@ -725,8 +726,11 @@ fn test_stake_smt_success() {
         output_stake_smt_data.as_bytes().len()
     );
     let outputs_data = vec![
-        Bytes::from(axon_stake_at_cell_data(100, output_stake_at_data)), // stake at cell
-        output_stake_smt_data.as_bytes(),                                // stake smt cell
+        Bytes::from(axon_stake_at_cell_data(
+            output_stake_at_amount,
+            output_stake_at_data,
+        )), // stake at cell
+        output_stake_smt_data.as_bytes(), // stake smt cell
     ];
 
     // prepare metadata cell_dep
@@ -792,10 +796,6 @@ fn test_stake_smt_success() {
         .0;
     println!("old proof: {:?}", old_proof);
 
-    // let lock_info = LockInfo {
-    //     addr: blake160(keypair.1.serialize().as_slice()),
-    //     amount: 100,
-    // };
     let lock_infos: BTreeSet<LockInfo> =
         vec![lock_info].into_iter().collect::<BTreeSet<LockInfo>>();
     let (new_bottom_root, _) = construct_lock_info_smt(&lock_infos);
@@ -856,7 +856,30 @@ fn test_stake_smt_success() {
         // .cell_dep(stake_smt_input_dep)
         .build();
     let tx = context.complete_tx(tx);
+    tx
+}
 
+#[test]
+fn test_stake_smt_success() {
+    // init context
+    let mut context = Context::default();
+    let input_stake_at_amount = 200;
+    let output_stake_at_amount = 200;
+
+    let input_stake_info_delta = stake::StakeInfoDelta::new_builder()
+        .is_increase(1.into())
+        .amount(axon_u128(input_stake_at_amount))
+        .inauguration_epoch(axon_u64(3))
+        .build();
+    let output_stake_info_delta = stake::StakeInfoDelta::new_builder().build();
+
+    let tx = construct_stake_smt_tx(
+        &mut context,
+        input_stake_info_delta,
+        output_stake_info_delta,
+        input_stake_at_amount,
+        output_stake_at_amount,
+    );
     // run
     let cycles = context
         .verify_tx(&tx, MAX_CYCLES)
@@ -864,12 +887,15 @@ fn test_stake_smt_success() {
     println!("consume cycles: {}", cycles);
 }
 
-// staker has staked 100 at, and updated to stake smt cell
-// staker then want to redeem 5 at , and updated to stake smt cell
-#[test]
-fn test_stake_smt_redeem_success() {
-    // init context
-    let mut context = Context::default();
+fn construct_stake_smt_unstake_tx(
+    context: &mut Context,
+    input_stake_info_delta: StakeInfoDelta,
+    output_stake_info_delta: StakeInfoDelta,
+    input_unstake_amount: u128,
+    input_stake_smt_amount: u128,
+    input_stake_at_amount: u128,
+    output_stake_at_amount: u128,
+) -> TransactionView {
     let secp256k1_data_bin = BUNDLED_CELL.get("specs/cells/secp256k1_data").unwrap();
     let secp256k1_data_out_point = context.deploy_cell(secp256k1_data_bin.to_vec().into());
     let secp256k1_data_dep = CellDep::new_builder()
@@ -925,13 +951,8 @@ fn test_stake_smt_redeem_success() {
         .build();
 
     // redeem 10 AT
-    let new_unstake_amount = 10;
     let inauguration_epoch = 2; // default epoch of checkpoint cell is 0
-    let input_stake_info_delta = stake::StakeInfoDelta::new_builder()
-        .is_increase(0.into())
-        .amount(axon_u128(new_unstake_amount))
-        .inauguration_epoch(axon_u64(inauguration_epoch))
-        .build();
+
     let input_stake_at_data = axon_stake_at_cell_data_without_amount(
         0,
         &keypair.1.serialize(),
@@ -959,10 +980,9 @@ fn test_stake_smt_redeem_success() {
     );
 
     println!("input stake infos of stake smt cell");
-    let old_stake_amount = 100;
     let old_lock_info = LockInfo {
         addr: l2_addr.as_slice().try_into().unwrap(),
-        amount: old_stake_amount,
+        amount: input_stake_smt_amount,
     };
     let input_stake_infos = vec![old_lock_info]
         .into_iter()
@@ -982,11 +1002,6 @@ fn test_stake_smt_redeem_success() {
         input_stake_smt_data.as_bytes(),
     );
 
-    // let withdraw_contract_bin: Bytes = Loader::default().load_binary("withdraw");
-    // let withdraw_contract_out_point = context.deploy_cell(withdraw_contract_bin);
-    // let withdraw_contract_dep = CellDep::new_builder()
-    //     .out_point(withdraw_contract_out_point.clone())
-    //     .build();
     let withdraw_lock_args = WithdrawArgs::new_builder()
         .addr(l2_addr.clone())
         .metadata_type_id(axon_byte32(&metadata_type_script.calc_script_hash()))
@@ -1031,7 +1046,7 @@ fn test_stake_smt_redeem_success() {
                         .type_(Some(stake_at_type_script.clone()).pack())
                         .build(),
                     Bytes::from(axon_stake_at_cell_data(
-                        old_stake_amount,
+                        input_stake_at_amount,
                         input_stake_at_data,
                     )),
                 ),
@@ -1069,7 +1084,6 @@ fn test_stake_smt_redeem_success() {
     ];
 
     // prepare outputs_data
-    let output_stake_info_delta = stake::StakeInfoDelta::new_builder().build();
     let output_stake_at_data = axon_stake_at_cell_data_without_amount(
         0,
         &keypair.1.serialize(),
@@ -1081,7 +1095,7 @@ fn test_stake_smt_redeem_success() {
 
     let new_lock_info = LockInfo {
         addr: l2_addr.as_slice().try_into().unwrap(),
-        amount: old_stake_amount - new_unstake_amount,
+        amount: input_stake_smt_amount - input_unstake_amount,
     };
     let output_stake_infos = vec![new_lock_info]
         .into_iter()
@@ -1098,18 +1112,18 @@ fn test_stake_smt_redeem_success() {
     let output_withdraw_infos = vec![
         (inauguration_epoch - 2 as u64, 0 as u128),
         (inauguration_epoch - 1, 0),
-        (inauguration_epoch, new_unstake_amount),
+        (inauguration_epoch, input_unstake_amount),
     ];
     let output_withdraw_data = axon_withdraw_at_cell_data_without_amount(output_withdraw_infos);
 
     let outputs_data = vec![
         Bytes::from(axon_stake_at_cell_data(
-            old_stake_amount - new_unstake_amount,
+            output_stake_at_amount,
             output_stake_at_data,
         )), // stake at cell
         output_stake_smt_data.as_bytes(), // stake smt cell
         Bytes::from(axon_withdraw_at_cell_data(
-            new_unstake_amount,
+            input_unstake_amount,
             output_withdraw_data,
         )), // withdraw at cell
     ];
@@ -1206,7 +1220,7 @@ fn test_stake_smt_redeem_success() {
 
     let stake_info = stake::StakeInfo::new_builder()
         .addr(l2_addr.clone())
-        .amount(axon_u128(old_stake_amount))
+        .amount(axon_u128(input_stake_smt_amount))
         .build(); // assume old stake smt is empty
     let stake_infos = stake::StakeInfos::new_builder().push(stake_info).build();
     let stake_smt_update_info = stake::StakeSmtUpdateInfo::new_builder()
@@ -1246,7 +1260,35 @@ fn test_stake_smt_redeem_success() {
         .cell_dep(metadata_script_dep)
         .build();
     let tx = context.complete_tx(tx);
+    tx
+}
 
+// staker has staked 100 at, and updated to stake smt cell
+// staker then want to redeem 5 at , and updated to stake smt cell
+#[test]
+fn test_stake_smt_redeem_success() {
+    // init context
+    let mut context = Context::default();
+    let input_unstake_amount = 10;
+    let input_stake_info_delta = stake::StakeInfoDelta::new_builder()
+        .is_increase(0.into())
+        .amount(axon_u128(input_unstake_amount))
+        .inauguration_epoch(axon_u64(2))
+        .build();
+    let input_stake_smt_amount = 100;
+    let input_stake_at_amount = 100;
+    let output_stake_info_delta = stake::StakeInfoDelta::new_builder().build();
+    let output_stake_at_amount = input_stake_at_amount - input_unstake_amount;
+
+    let tx = construct_stake_smt_unstake_tx(
+        &mut context,
+        input_stake_info_delta,
+        output_stake_info_delta,
+        input_unstake_amount,
+        input_stake_smt_amount,
+        input_stake_at_amount,
+        output_stake_at_amount,
+    );
     // run
     let cycles = context
         .verify_tx(&tx, MAX_CYCLES)


### PR DESCRIPTION
1. delegate more ATs to staker
2. undelegate at to staker. As undelegate is just a record to take effect until updated to delegate smt cell, I didn't implement strict check on this. For example, a delegatator can undelegate more ATs than the amount it has delegated.
3. update records in delegate AT cells to delegate smt cell. 
4. staker stake , unstake 
The test cases above are not complete, still needs more.