### PR TITLE
feat: pub_key changed from Byte65 to Byte33

### DIFF
--- a/common/types/schemas/basic.mol
+++ b/common/types/schemas/basic.mol
@@ -3,6 +3,7 @@ array Byte8  [byte; 8];
 array Byte16 [byte; 16];
 array Byte20 [byte; 20];
 array Byte32 [byte; 32];
+array Byte33 [byte; 33];
 array Byte48 [byte; 48];
 array Byte65 [byte; 65];
 array Byte97 [byte; 97];

--- a/common/types/schemas/checkpoint.json
+++ b/common/types/schemas/checkpoint.json
@@ -130,6 +130,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/schemas/delegate.json
+++ b/common/types/schemas/delegate.json
@@ -306,6 +306,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/schemas/issue.json
+++ b/common/types/schemas/issue.json
@@ -67,6 +67,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/schemas/metadata.json
+++ b/common/types/schemas/metadata.json
@@ -18,7 +18,7 @@
         },
         {
           "name": "pub_key",
-          "type": "Byte65"
+          "type": "Byte33"
         },
         {
           "name": "address",
@@ -380,6 +380,13 @@
       "name": "Byte32",
       "item": "byte",
       "item_count": 32,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
       "imported_depth": 1
     },
     {

--- a/common/types/schemas/metadata.mol
+++ b/common/types/schemas/metadata.mol
@@ -2,7 +2,7 @@ import basic;
 
 table Validator {
     bls_pub_key:    Byte48,
-    pub_key:        Byte65,
+    pub_key:        Byte33,
     address:        Identity,
     propose_weight: Uint32,
     vote_weight:    Uint32,

--- a/common/types/schemas/reward.json
+++ b/common/types/schemas/reward.json
@@ -188,6 +188,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/schemas/selection.json
+++ b/common/types/schemas/selection.json
@@ -59,6 +59,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/schemas/stake.json
+++ b/common/types/schemas/stake.json
@@ -78,7 +78,7 @@
         },
         {
           "name": "l1_pub_key",
-          "type": "Byte65"
+          "type": "Byte33"
         },
         {
           "name": "bls_pub_key",
@@ -241,6 +241,13 @@
       "name": "Byte32",
       "item": "byte",
       "item_count": 32,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
       "imported_depth": 1
     },
     {

--- a/common/types/schemas/stake.mol
+++ b/common/types/schemas/stake.mol
@@ -23,7 +23,7 @@ table DelegateRequirementInfo {
 
 table StakeAtCellLockData {
     version:             byte,
-    l1_pub_key:          Byte65,
+    l1_pub_key:          Byte33,
     bls_pub_key:         Byte48,
     l1_address:          Identity,
     l2_address:          Identity,

--- a/common/types/schemas/withdraw.json
+++ b/common/types/schemas/withdraw.json
@@ -121,6 +121,13 @@
     },
     {
       "type": "array",
+      "name": "Byte33",
+      "item": "byte",
+      "item_count": 33,
+      "imported_depth": 1
+    },
+    {
+      "type": "array",
       "name": "Byte48",
       "item": "byte",
       "item_count": 48,

--- a/common/types/src/generated/basic.rs
+++ b/common/types/src/generated/basic.rs
@@ -1815,6 +1815,593 @@ impl molecule::prelude::Builder for Byte32Builder {
     }
 }
 #[derive(Clone)]
+pub struct Byte33(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for Byte33 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl ::core::fmt::Debug for Byte33 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl ::core::fmt::Display for Byte33 {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        let raw_data = hex_string(&self.raw_data());
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl ::core::default::Default for Byte33 {
+    fn default() -> Self {
+        let v: Vec<u8> = vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
+        ];
+        Byte33::new_unchecked(v.into())
+    }
+}
+impl Byte33 {
+    pub const TOTAL_SIZE: usize = 33;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 33;
+    pub fn nth0(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(0..1))
+    }
+    pub fn nth1(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(1..2))
+    }
+    pub fn nth2(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(2..3))
+    }
+    pub fn nth3(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(3..4))
+    }
+    pub fn nth4(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(4..5))
+    }
+    pub fn nth5(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(5..6))
+    }
+    pub fn nth6(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(6..7))
+    }
+    pub fn nth7(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(7..8))
+    }
+    pub fn nth8(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(8..9))
+    }
+    pub fn nth9(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(9..10))
+    }
+    pub fn nth10(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(10..11))
+    }
+    pub fn nth11(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(11..12))
+    }
+    pub fn nth12(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(12..13))
+    }
+    pub fn nth13(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(13..14))
+    }
+    pub fn nth14(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(14..15))
+    }
+    pub fn nth15(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(15..16))
+    }
+    pub fn nth16(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(16..17))
+    }
+    pub fn nth17(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(17..18))
+    }
+    pub fn nth18(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(18..19))
+    }
+    pub fn nth19(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(19..20))
+    }
+    pub fn nth20(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(20..21))
+    }
+    pub fn nth21(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(21..22))
+    }
+    pub fn nth22(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(22..23))
+    }
+    pub fn nth23(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(23..24))
+    }
+    pub fn nth24(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(24..25))
+    }
+    pub fn nth25(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(25..26))
+    }
+    pub fn nth26(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(26..27))
+    }
+    pub fn nth27(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(27..28))
+    }
+    pub fn nth28(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(28..29))
+    }
+    pub fn nth29(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(29..30))
+    }
+    pub fn nth30(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(30..31))
+    }
+    pub fn nth31(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(31..32))
+    }
+    pub fn nth32(&self) -> Byte {
+        Byte::new_unchecked(self.0.slice(32..33))
+    }
+    pub fn raw_data(&self) -> molecule::bytes::Bytes {
+        self.as_bytes()
+    }
+    pub fn as_reader<'r>(&'r self) -> Byte33Reader<'r> {
+        Byte33Reader::new_unchecked(self.as_slice())
+    }
+}
+impl molecule::prelude::Entity for Byte33 {
+    type Builder = Byte33Builder;
+    const NAME: &'static str = "Byte33";
+    fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
+        Byte33(data)
+    }
+    fn as_bytes(&self) -> molecule::bytes::Bytes {
+        self.0.clone()
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0[..]
+    }
+    fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte33Reader::from_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
+        Byte33Reader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+    }
+    fn new_builder() -> Self::Builder {
+        ::core::default::Default::default()
+    }
+    fn as_builder(self) -> Self::Builder {
+        Self::new_builder().set([
+            self.nth0(),
+            self.nth1(),
+            self.nth2(),
+            self.nth3(),
+            self.nth4(),
+            self.nth5(),
+            self.nth6(),
+            self.nth7(),
+            self.nth8(),
+            self.nth9(),
+            self.nth10(),
+            self.nth11(),
+            self.nth12(),
+            self.nth13(),
+            self.nth14(),
+            self.nth15(),
+            self.nth16(),
+            self.nth17(),
+            self.nth18(),
+            self.nth19(),
+            self.nth20(),
+            self.nth21(),
+            self.nth22(),
+            self.nth23(),
+            self.nth24(),
+            self.nth25(),
+            self.nth26(),
+            self.nth27(),
+            self.nth28(),
+            self.nth29(),
+            self.nth30(),
+            self.nth31(),
+            self.nth32(),
+        ])
+    }
+}
+#[derive(Clone, Copy)]
+pub struct Byte33Reader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for Byte33Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", hex_string(self.as_slice()))
+    }
+}
+impl<'r> ::core::fmt::Debug for Byte33Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:#x})", Self::NAME, self)
+    }
+}
+impl<'r> ::core::fmt::Display for Byte33Reader<'r> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        use molecule::hex_string;
+        let raw_data = hex_string(&self.raw_data());
+        write!(f, "{}(0x{})", Self::NAME, raw_data)
+    }
+}
+impl<'r> Byte33Reader<'r> {
+    pub const TOTAL_SIZE: usize = 33;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 33;
+    pub fn nth0(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[0..1])
+    }
+    pub fn nth1(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[1..2])
+    }
+    pub fn nth2(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[2..3])
+    }
+    pub fn nth3(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[3..4])
+    }
+    pub fn nth4(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[4..5])
+    }
+    pub fn nth5(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[5..6])
+    }
+    pub fn nth6(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[6..7])
+    }
+    pub fn nth7(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[7..8])
+    }
+    pub fn nth8(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[8..9])
+    }
+    pub fn nth9(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[9..10])
+    }
+    pub fn nth10(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[10..11])
+    }
+    pub fn nth11(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[11..12])
+    }
+    pub fn nth12(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[12..13])
+    }
+    pub fn nth13(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[13..14])
+    }
+    pub fn nth14(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[14..15])
+    }
+    pub fn nth15(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[15..16])
+    }
+    pub fn nth16(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[16..17])
+    }
+    pub fn nth17(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[17..18])
+    }
+    pub fn nth18(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[18..19])
+    }
+    pub fn nth19(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[19..20])
+    }
+    pub fn nth20(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[20..21])
+    }
+    pub fn nth21(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[21..22])
+    }
+    pub fn nth22(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[22..23])
+    }
+    pub fn nth23(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[23..24])
+    }
+    pub fn nth24(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[24..25])
+    }
+    pub fn nth25(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[25..26])
+    }
+    pub fn nth26(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[26..27])
+    }
+    pub fn nth27(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[27..28])
+    }
+    pub fn nth28(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[28..29])
+    }
+    pub fn nth29(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[29..30])
+    }
+    pub fn nth30(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[30..31])
+    }
+    pub fn nth31(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[31..32])
+    }
+    pub fn nth32(&self) -> ByteReader<'r> {
+        ByteReader::new_unchecked(&self.as_slice()[32..33])
+    }
+    pub fn raw_data(&self) -> &'r [u8] {
+        self.as_slice()
+    }
+}
+impl<'r> molecule::prelude::Reader<'r> for Byte33Reader<'r> {
+    type Entity = Byte33;
+    const NAME: &'static str = "Byte33Reader";
+    fn to_entity(&self) -> Self::Entity {
+        Self::Entity::new_unchecked(self.as_slice().to_owned().into())
+    }
+    fn new_unchecked(slice: &'r [u8]) -> Self {
+        Byte33Reader(slice)
+    }
+    fn as_slice(&self) -> &'r [u8] {
+        self.0
+    }
+    fn verify(slice: &[u8], _compatible: bool) -> molecule::error::VerificationResult<()> {
+        use molecule::verification_error as ve;
+        let slice_len = slice.len();
+        if slice_len != Self::TOTAL_SIZE {
+            return ve!(Self, TotalSizeNotMatch, Self::TOTAL_SIZE, slice_len);
+        }
+        Ok(())
+    }
+}
+pub struct Byte33Builder(pub(crate) [Byte; 33]);
+impl ::core::fmt::Debug for Byte33Builder {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "{}({:?})", Self::NAME, &self.0[..])
+    }
+}
+impl ::core::default::Default for Byte33Builder {
+    fn default() -> Self {
+        Byte33Builder([
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+            Byte::default(),
+        ])
+    }
+}
+impl Byte33Builder {
+    pub const TOTAL_SIZE: usize = 33;
+    pub const ITEM_SIZE: usize = 1;
+    pub const ITEM_COUNT: usize = 33;
+    pub fn set(mut self, v: [Byte; 33]) -> Self {
+        self.0 = v;
+        self
+    }
+    pub fn nth0(mut self, v: Byte) -> Self {
+        self.0[0] = v;
+        self
+    }
+    pub fn nth1(mut self, v: Byte) -> Self {
+        self.0[1] = v;
+        self
+    }
+    pub fn nth2(mut self, v: Byte) -> Self {
+        self.0[2] = v;
+        self
+    }
+    pub fn nth3(mut self, v: Byte) -> Self {
+        self.0[3] = v;
+        self
+    }
+    pub fn nth4(mut self, v: Byte) -> Self {
+        self.0[4] = v;
+        self
+    }
+    pub fn nth5(mut self, v: Byte) -> Self {
+        self.0[5] = v;
+        self
+    }
+    pub fn nth6(mut self, v: Byte) -> Self {
+        self.0[6] = v;
+        self
+    }
+    pub fn nth7(mut self, v: Byte) -> Self {
+        self.0[7] = v;
+        self
+    }
+    pub fn nth8(mut self, v: Byte) -> Self {
+        self.0[8] = v;
+        self
+    }
+    pub fn nth9(mut self, v: Byte) -> Self {
+        self.0[9] = v;
+        self
+    }
+    pub fn nth10(mut self, v: Byte) -> Self {
+        self.0[10] = v;
+        self
+    }
+    pub fn nth11(mut self, v: Byte) -> Self {
+        self.0[11] = v;
+        self
+    }
+    pub fn nth12(mut self, v: Byte) -> Self {
+        self.0[12] = v;
+        self
+    }
+    pub fn nth13(mut self, v: Byte) -> Self {
+        self.0[13] = v;
+        self
+    }
+    pub fn nth14(mut self, v: Byte) -> Self {
+        self.0[14] = v;
+        self
+    }
+    pub fn nth15(mut self, v: Byte) -> Self {
+        self.0[15] = v;
+        self
+    }
+    pub fn nth16(mut self, v: Byte) -> Self {
+        self.0[16] = v;
+        self
+    }
+    pub fn nth17(mut self, v: Byte) -> Self {
+        self.0[17] = v;
+        self
+    }
+    pub fn nth18(mut self, v: Byte) -> Self {
+        self.0[18] = v;
+        self
+    }
+    pub fn nth19(mut self, v: Byte) -> Self {
+        self.0[19] = v;
+        self
+    }
+    pub fn nth20(mut self, v: Byte) -> Self {
+        self.0[20] = v;
+        self
+    }
+    pub fn nth21(mut self, v: Byte) -> Self {
+        self.0[21] = v;
+        self
+    }
+    pub fn nth22(mut self, v: Byte) -> Self {
+        self.0[22] = v;
+        self
+    }
+    pub fn nth23(mut self, v: Byte) -> Self {
+        self.0[23] = v;
+        self
+    }
+    pub fn nth24(mut self, v: Byte) -> Self {
+        self.0[24] = v;
+        self
+    }
+    pub fn nth25(mut self, v: Byte) -> Self {
+        self.0[25] = v;
+        self
+    }
+    pub fn nth26(mut self, v: Byte) -> Self {
+        self.0[26] = v;
+        self
+    }
+    pub fn nth27(mut self, v: Byte) -> Self {
+        self.0[27] = v;
+        self
+    }
+    pub fn nth28(mut self, v: Byte) -> Self {
+        self.0[28] = v;
+        self
+    }
+    pub fn nth29(mut self, v: Byte) -> Self {
+        self.0[29] = v;
+        self
+    }
+    pub fn nth30(mut self, v: Byte) -> Self {
+        self.0[30] = v;
+        self
+    }
+    pub fn nth31(mut self, v: Byte) -> Self {
+        self.0[31] = v;
+        self
+    }
+    pub fn nth32(mut self, v: Byte) -> Self {
+        self.0[32] = v;
+        self
+    }
+}
+impl molecule::prelude::Builder for Byte33Builder {
+    type Entity = Byte33;
+    const NAME: &'static str = "Byte33Builder";
+    fn expected_length(&self) -> usize {
+        Self::TOTAL_SIZE
+    }
+    fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
+        writer.write_all(self.0[0].as_slice())?;
+        writer.write_all(self.0[1].as_slice())?;
+        writer.write_all(self.0[2].as_slice())?;
+        writer.write_all(self.0[3].as_slice())?;
+        writer.write_all(self.0[4].as_slice())?;
+        writer.write_all(self.0[5].as_slice())?;
+        writer.write_all(self.0[6].as_slice())?;
+        writer.write_all(self.0[7].as_slice())?;
+        writer.write_all(self.0[8].as_slice())?;
+        writer.write_all(self.0[9].as_slice())?;
+        writer.write_all(self.0[10].as_slice())?;
+        writer.write_all(self.0[11].as_slice())?;
+        writer.write_all(self.0[12].as_slice())?;
+        writer.write_all(self.0[13].as_slice())?;
+        writer.write_all(self.0[14].as_slice())?;
+        writer.write_all(self.0[15].as_slice())?;
+        writer.write_all(self.0[16].as_slice())?;
+        writer.write_all(self.0[17].as_slice())?;
+        writer.write_all(self.0[18].as_slice())?;
+        writer.write_all(self.0[19].as_slice())?;
+        writer.write_all(self.0[20].as_slice())?;
+        writer.write_all(self.0[21].as_slice())?;
+        writer.write_all(self.0[22].as_slice())?;
+        writer.write_all(self.0[23].as_slice())?;
+        writer.write_all(self.0[24].as_slice())?;
+        writer.write_all(self.0[25].as_slice())?;
+        writer.write_all(self.0[26].as_slice())?;
+        writer.write_all(self.0[27].as_slice())?;
+        writer.write_all(self.0[28].as_slice())?;
+        writer.write_all(self.0[29].as_slice())?;
+        writer.write_all(self.0[30].as_slice())?;
+        writer.write_all(self.0[31].as_slice())?;
+        writer.write_all(self.0[32].as_slice())?;
+        Ok(())
+    }
+    fn build(&self) -> Self::Entity {
+        let mut inner = Vec::with_capacity(self.expected_length());
+        self.write(&mut inner)
+            .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
+        Byte33::new_unchecked(inner.into())
+    }
+}
+#[derive(Clone)]
 pub struct Byte48(molecule::bytes::Bytes);
 impl ::core::fmt::LowerHex for Byte48 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {

--- a/common/types/src/generated/metadata.rs
+++ b/common/types/src/generated/metadata.rs
@@ -37,13 +37,12 @@ impl ::core::fmt::Display for Validator {
 impl ::core::default::Default for Validator {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            177, 0, 0, 0, 28, 0, 0, 0, 76, 0, 0, 0, 141, 0, 0, 0, 161, 0, 0, 0, 165, 0, 0, 0, 169,
+            145, 0, 0, 0, 28, 0, 0, 0, 76, 0, 0, 0, 109, 0, 0, 0, 129, 0, 0, 0, 133, 0, 0, 0, 137,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0,
         ];
         Validator::new_unchecked(v.into())
     }
@@ -72,11 +71,11 @@ impl Validator {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         Byte48::new_unchecked(self.0.slice(start..end))
     }
-    pub fn pub_key(&self) -> Byte65 {
+    pub fn pub_key(&self) -> Byte33 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte65::new_unchecked(self.0.slice(start..end))
+        Byte33::new_unchecked(self.0.slice(start..end))
     }
     pub fn address(&self) -> Identity {
         let slice = self.as_slice();
@@ -197,11 +196,11 @@ impl<'r> ValidatorReader<'r> {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         Byte48Reader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn pub_key(&self) -> Byte65Reader<'r> {
+    pub fn pub_key(&self) -> Byte33Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte65Reader::new_unchecked(&self.as_slice()[start..end])
+        Byte33Reader::new_unchecked(&self.as_slice()[start..end])
     }
     pub fn address(&self) -> IdentityReader<'r> {
         let slice = self.as_slice();
@@ -282,7 +281,7 @@ impl<'r> molecule::prelude::Reader<'r> for ValidatorReader<'r> {
             return ve!(Self, OffsetsNotMatch);
         }
         Byte48Reader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        Byte65Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Byte33Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         IdentityReader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         Uint32Reader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
         Uint32Reader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
@@ -293,7 +292,7 @@ impl<'r> molecule::prelude::Reader<'r> for ValidatorReader<'r> {
 #[derive(Debug, Default)]
 pub struct ValidatorBuilder {
     pub(crate) bls_pub_key: Byte48,
-    pub(crate) pub_key: Byte65,
+    pub(crate) pub_key: Byte33,
     pub(crate) address: Identity,
     pub(crate) propose_weight: Uint32,
     pub(crate) vote_weight: Uint32,
@@ -305,7 +304,7 @@ impl ValidatorBuilder {
         self.bls_pub_key = v;
         self
     }
-    pub fn pub_key(mut self, v: Byte65) -> Self {
+    pub fn pub_key(mut self, v: Byte33) -> Self {
         self.pub_key = v;
         self
     }

--- a/common/types/src/generated/stake.rs
+++ b/common/types/src/generated/stake.rs
@@ -949,20 +949,18 @@ impl ::core::fmt::Display for StakeAtCellLockData {
 impl ::core::default::Default for StakeAtCellLockData {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            115, 1, 0, 0, 36, 0, 0, 0, 37, 0, 0, 0, 102, 0, 0, 0, 150, 0, 0, 0, 170, 0, 0, 0, 190,
-            0, 0, 0, 222, 0, 0, 0, 74, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            83, 1, 0, 0, 36, 0, 0, 0, 37, 0, 0, 0, 70, 0, 0, 0, 118, 0, 0, 0, 138, 0, 0, 0, 158, 0,
+            0, 0, 190, 0, 0, 0, 42, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 12, 0, 0, 0,
+            44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0,
-            12, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 16, 0, 0, 0, 17, 0,
-            0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 16, 0, 0, 0, 17, 0, 0, 0, 33, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ];
         StakeAtCellLockData::new_unchecked(v.into())
     }
@@ -991,11 +989,11 @@ impl StakeAtCellLockData {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         Byte::new_unchecked(self.0.slice(start..end))
     }
-    pub fn l1_pub_key(&self) -> Byte65 {
+    pub fn l1_pub_key(&self) -> Byte33 {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte65::new_unchecked(self.0.slice(start..end))
+        Byte33::new_unchecked(self.0.slice(start..end))
     }
     pub fn bls_pub_key(&self) -> Byte48 {
         let slice = self.as_slice();
@@ -1132,11 +1130,11 @@ impl<'r> StakeAtCellLockDataReader<'r> {
         let end = molecule::unpack_number(&slice[8..]) as usize;
         ByteReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn l1_pub_key(&self) -> Byte65Reader<'r> {
+    pub fn l1_pub_key(&self) -> Byte33Reader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[8..]) as usize;
         let end = molecule::unpack_number(&slice[12..]) as usize;
-        Byte65Reader::new_unchecked(&self.as_slice()[start..end])
+        Byte33Reader::new_unchecked(&self.as_slice()[start..end])
     }
     pub fn bls_pub_key(&self) -> Byte48Reader<'r> {
         let slice = self.as_slice();
@@ -1229,7 +1227,7 @@ impl<'r> molecule::prelude::Reader<'r> for StakeAtCellLockDataReader<'r> {
             return ve!(Self, OffsetsNotMatch);
         }
         ByteReader::verify(&slice[offsets[0]..offsets[1]], compatible)?;
-        Byte65Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
+        Byte33Reader::verify(&slice[offsets[1]..offsets[2]], compatible)?;
         Byte48Reader::verify(&slice[offsets[2]..offsets[3]], compatible)?;
         IdentityReader::verify(&slice[offsets[3]..offsets[4]], compatible)?;
         IdentityReader::verify(&slice[offsets[4]..offsets[5]], compatible)?;
@@ -1242,7 +1240,7 @@ impl<'r> molecule::prelude::Reader<'r> for StakeAtCellLockDataReader<'r> {
 #[derive(Debug, Default)]
 pub struct StakeAtCellLockDataBuilder {
     pub(crate) version: Byte,
-    pub(crate) l1_pub_key: Byte65,
+    pub(crate) l1_pub_key: Byte33,
     pub(crate) bls_pub_key: Byte48,
     pub(crate) l1_address: Identity,
     pub(crate) l2_address: Identity,
@@ -1256,7 +1254,7 @@ impl StakeAtCellLockDataBuilder {
         self.version = v;
         self
     }
-    pub fn l1_pub_key(mut self, v: Byte65) -> Self {
+    pub fn l1_pub_key(mut self, v: Byte33) -> Self {
         self.l1_pub_key = v;
         self
     }
@@ -1709,20 +1707,19 @@ impl ::core::fmt::Display for StakeAtCellData {
 impl ::core::default::Default for StakeAtCellData {
     fn default() -> Self {
         let v: Vec<u8> = vec![
-            131, 1, 0, 0, 12, 0, 0, 0, 127, 1, 0, 0, 115, 1, 0, 0, 36, 0, 0, 0, 37, 0, 0, 0, 102,
-            0, 0, 0, 150, 0, 0, 0, 170, 0, 0, 0, 190, 0, 0, 0, 222, 0, 0, 0, 74, 1, 0, 0, 0, 0, 0,
+            99, 1, 0, 0, 12, 0, 0, 0, 95, 1, 0, 0, 83, 1, 0, 0, 36, 0, 0, 0, 37, 0, 0, 0, 70, 0, 0,
+            0, 118, 0, 0, 0, 138, 0, 0, 0, 158, 0, 0, 0, 190, 0, 0, 0, 42, 1, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 12, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 108, 0, 0, 0, 12, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 41, 0, 0, 0, 16, 0, 0, 0, 17, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0,
+            0, 16, 0, 0, 0, 17, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
         ];
         StakeAtCellData::new_unchecked(v.into())
     }

--- a/tests/src/helper.rs
+++ b/tests/src/helper.rs
@@ -78,6 +78,10 @@ pub fn axon_array32_byte32(bytes: [u8; 32]) -> basic::Byte32 {
     basic::Byte32::new_unchecked(bytes.to_vec().into())
 }
 
+pub fn axon_byte33(bytes: Vec<u8>) -> basic::Byte33 {
+    basic::Byte33::new_unchecked(bytes.into())
+}
+
 pub fn axon_byte65(bytes: Vec<u8>) -> basic::Byte65 {
     basic::Byte65::new_unchecked(bytes.into())
 }

--- a/tests/src/metadata.rs
+++ b/tests/src/metadata.rs
@@ -96,11 +96,9 @@ fn test_metadata_creation_success() {
         .quorum(axon_u16(2))
         .build();
     let metadata1 = metadata0.clone();
-    let metadata2 = metadata0.clone();
     let metadata_list = MetadataList::new_builder()
         .push(metadata0)
         .push(metadata1)
-        .push(metadata2)
         .build();
     println!(
         "checkpoint script: {:?}",


### PR DESCRIPTION
The pub_key for axon is 33 bytes compressed key. `pub_key` in this repo should be the same. Moreover, 33 bytes consume less capacity.
`capsule build` ok
`cargo test` returns 
>> 79 passed; 0 failed; 0 ignored;